### PR TITLE
Feat: 탐색화면 카테고리뷰 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-intersection-observer": "^10.0.2",
     "react-router-dom": "^7.11.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
+      react-intersection-observer:
+        specifier: ^10.0.2
+        version: 10.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-router-dom:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2074,6 +2077,15 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-intersection-observer@10.0.2:
+    resolution: {integrity: sha512-lAMzxVWrBko6SLd1jx6l84fVrzJu91hpxHlvD2as2Wec9mDCjdYXwc5xNOFBchpeBir0Y7AGBW+C/AYMa7CSFg==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -4568,6 +4580,12 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-intersection-observer@10.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
 
   react-refresh@0.18.0: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,24 @@
 import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
+import { storage } from "./apis/storage";
 import { useAttendanceCheck } from "./hooks/attendance/useAttendanceCheck";
-import { useAuth } from "./hooks/useAuth";
 import router from "./routes/router";
 
 function App() {
-  useAuth();
   const { handleCheckAttendance } = useAttendanceCheck();
 
   useEffect(() => {
+    const token = storage.getToken();
+    if (!token) return;
+
     handleCheckAttendance();
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
-        handleCheckAttendance();
+        const currentToken = storage.getToken();
+        if (currentToken) {
+          handleCheckAttendance();
+        }
       }
     };
 

--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -43,9 +43,8 @@ const handleTokenRefresh = async (
     storage.setToken(newToken);
     originalConfig.headers.Authorization = `Bearer ${newToken}`;
     return instance(originalConfig);
-  } catch {
+  } catch (refreshError) {
     storage.removeToken();
-    window.location.href = "/login";
     return Promise.reject(error);
   } finally {
     isRefreshing = false;

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -27,7 +27,7 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
     if (location.pathname === "/login" && isAuthenticated) {
       navigate("/", { replace: true });
     }
-  }, [location.pathname, navigate, isAuthenticated, isLoading]);
+  }, [location.pathname, navigate, isAuthenticated, isLoading, isPublicPath]);
 
   if (isLoading) {
     return (
@@ -35,6 +35,10 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
         <LoadingSpinner className="size-60" />
       </div>
     );
+  }
+
+  if (!isPublicPath && !isAuthenticated) {
+    return null;
   }
 
   return <>{children}</>;

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { storage } from "@/apis/storage";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { useAuth } from "@/hooks/useAuth";
 
 interface AuthGuardProps {
   children: ReactNode;
@@ -11,23 +12,29 @@ const PUBLIC_PATHS = ["/login", "/signup", "/find-id", "/reset-password"];
 const AuthGuard = ({ children }: AuthGuardProps) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isLoading, isAuthenticated } = useAuth();
 
   const isPublicPath = PUBLIC_PATHS.includes(location.pathname);
-  const accessToken = storage.getToken();
 
   useEffect(() => {
-    if (!isPublicPath && !accessToken) {
+    if (isLoading) return;
+
+    if (!isPublicPath && !isAuthenticated) {
       navigate("/login", { replace: true });
       return;
     }
 
-    if (location.pathname === "/login" && accessToken) {
+    if (location.pathname === "/login" && isAuthenticated) {
       navigate("/", { replace: true });
     }
-  }, [location.pathname, navigate, isPublicPath, accessToken]);
+  }, [location.pathname, navigate, isAuthenticated, isLoading]);
 
-  if (!isPublicPath && !accessToken) {
-    return null;
+  if (isLoading) {
+    return (
+      <div className="flex h-dvh items-center justify-center">
+        <LoadingSpinner className="size-60" />
+      </div>
+    );
   }
 
   return <>{children}</>;

--- a/src/constants/missions/categories.ts
+++ b/src/constants/missions/categories.ts
@@ -1,0 +1,59 @@
+import type { Category } from "@/types/mission/mission";
+
+export type { Category };
+
+export const MAIN_CATEGORIES = [
+  "경제와 금융",
+  "IT",
+  "영어",
+  "시사",
+  "인문",
+] as const;
+
+export type MainCategory = (typeof MAIN_CATEGORIES)[number];
+
+export const CATEGORY_ID_MAP: Record<MainCategory, number> = {
+  "경제와 금융": 10,
+  IT: 20,
+  영어: 30,
+  시사: 40,
+  인문: 50,
+};
+
+export const SUB_CATEGORIES: Record<MainCategory, Category[]> = {
+  "경제와 금융": [
+    { categoryId: 11, name: "경제 흐름" },
+    { categoryId: 12, name: "금융상식" },
+    { categoryId: 13, name: "기업과 산업" },
+    { categoryId: 14, name: "부동산" },
+    { categoryId: 15, name: "투자기초" },
+  ],
+  IT: [
+    { categoryId: 21, name: "CS" },
+    { categoryId: 22, name: "트렌드" },
+    { categoryId: 23, name: "데이터" },
+    { categoryId: 24, name: "IT 생태계" },
+    { categoryId: 25, name: "반도체" },
+  ],
+  영어: [
+    { categoryId: 31, name: "콩글리시" },
+    { categoryId: 32, name: "비즈니스" },
+    { categoryId: 33, name: "문법과 어휘" },
+    { categoryId: 34, name: "글로벌 현장" },
+    { categoryId: 35, name: "영어 뉴스" },
+  ],
+  시사: [
+    { categoryId: 41, name: "사회,정책" },
+    { categoryId: 42, name: "마케팅" },
+    { categoryId: 43, name: "문화" },
+    { categoryId: 44, name: "환경" },
+    { categoryId: 45, name: "국제,외교" },
+  ],
+  인문: [
+    { categoryId: 51, name: "철학 및 심리" },
+    { categoryId: 52, name: "역사" },
+    { categoryId: 53, name: "문화" },
+    { categoryId: 54, name: "경험" },
+    { categoryId: 55, name: "예술" },
+  ],
+};

--- a/src/mocks/data/missions.ts
+++ b/src/mocks/data/missions.ts
@@ -1,0 +1,84 @@
+import type {
+  MissionApiResponse,
+  MissionsPageResponse,
+} from "@/types/mission/mission";
+
+// 목 데이터 생성 헬퍼
+const createMockMission = (
+  id: number,
+  categoryName: string
+): MissionApiResponse => ({
+  missionId: id,
+  title: `[${categoryName}] 테스트 미션 #${id}`,
+  durationMinutes: Math.floor(Math.random() * 10) + 3, // 3~12분
+  category: categoryName,
+  quizCount: Math.floor(Math.random() * 5) + 3, // 3~7개
+  keywords: [
+    `키워드${(id % 5) + 1}`,
+    `키워드${(id % 3) + 1}`,
+    `키워드${(id % 7) + 1}`,
+  ],
+  isScrapped: Math.random() > 0.5,
+  videoUrl: `https://example.com/video${id}.mp4`,
+  description: `테스트 미션 #${id}의 설명입니다.`,
+});
+
+// 카테고리별 목 미션 생성 (각 카테고리당 30개)
+export const generateMockMissions = (
+  categoryName: string,
+  page: number,
+  size: number
+): MissionsPageResponse => {
+  const totalMissions = 30; // 총 30개의 미션
+  const startId = page * size + 1;
+  const missions: MissionApiResponse[] = [];
+
+  for (let i = 0; i < size; i++) {
+    const missionId = startId + i;
+    if (missionId <= totalMissions) {
+      missions.push(createMockMission(missionId, categoryName));
+    }
+  }
+
+  return {
+    missions,
+    hasNext: startId + size <= totalMissions,
+  };
+};
+
+// 추천 미션 목 데이터
+export const MOCK_RECOMMENDED_MISSIONS: MissionApiResponse[] = [
+  {
+    missionId: 101,
+    title: "오늘의 추천: 경제 뉴스 핵심 정리",
+    durationMinutes: 5,
+    category: "경제와 금융",
+    quizCount: 3,
+    keywords: ["경제", "뉴스", "시사"],
+    isScrapped: false,
+    videoUrl: "https://example.com/recommended1.mp4",
+    description: "오늘의 경제 뉴스를 빠르게 정리합니다.",
+  },
+  {
+    missionId: 102,
+    title: "오늘의 추천: IT 트렌드 알아보기",
+    durationMinutes: 7,
+    category: "IT",
+    quizCount: 4,
+    keywords: ["IT", "트렌드", "기술"],
+    isScrapped: true,
+    videoUrl: "https://example.com/recommended2.mp4",
+    description: "최신 IT 트렌드를 살펴봅니다.",
+  },
+  {
+    missionId: 103,
+    title: "오늘의 추천: 비즈니스 영어 표현",
+    durationMinutes: 10,
+    category: "영어",
+    quizCount: 5,
+    keywords: ["영어", "비즈니스", "회화"],
+    isScrapped: false,
+    videoUrl: "https://example.com/recommended3.mp4",
+    description: "실무에서 자주 쓰는 영어 표현을 배웁니다.",
+  },
+];

--- a/src/pages/search/components/CategoryButton.tsx
+++ b/src/pages/search/components/CategoryButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/common/button/Button";
-import type { MainCategory } from "@/mocks/search/mission";
+import type { MainCategory } from "@/constants/missions/categories";
 import { cn } from "@/utils/cn/cn";
 
 interface CategoryButtonProps {
@@ -19,7 +19,7 @@ export default function CategoryButton({
       onClick={() => onClick(category)}
       className={cn(
         "heading-5 shrink-0 grow whitespace-nowrap",
-        isSelected ? "border-black border-b text-black" : "text-gray-500",
+        isSelected ? "border-black border-b text-black" : "text-gray-500"
       )}
     >
       {category}

--- a/src/pages/search/components/CategoryMissionInfiniteList.tsx
+++ b/src/pages/search/components/CategoryMissionInfiniteList.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useMemo } from "react";
+import { useInView } from "react-intersection-observer";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import MissionCard from "@/components/MissionCard";
+import { useCategoryMissionsInfinite } from "../hooks/useQuery/useCategoryMissionsInfinite";
+
+interface CategoryMissionInfiniteListProps {
+  categoryId: number;
+  subcategoryId: number;
+  seed: number;
+  swipeHandlers: Record<string, unknown>;
+}
+
+export default function CategoryMissionInfiniteList({
+  categoryId,
+  subcategoryId,
+  seed,
+  swipeHandlers,
+}: CategoryMissionInfiniteListProps) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useCategoryMissionsInfinite({
+      categoryId,
+      subcategoryId,
+      seed,
+    });
+
+  const { ref, inView } = useInView({
+    threshold: 0.1,
+    rootMargin: "300px",
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const missions = useMemo(
+    () =>
+      data.pages
+        .flatMap((page) => page.missions)
+        .map((m) => ({
+          id: m.missionId,
+          title: m.title,
+          keywords: m.keywords,
+          minute: m.durationMinutes,
+          category: m.category,
+          quizCount: m.quizCount,
+          isLiked: m.isScrapped,
+        })),
+    [data.pages]
+  );
+
+  if (missions.length === 0) {
+    return (
+      <div className="mt-50 flex justify-center">
+        <span className="body-2 text-gray-400">미션이 없습니다</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[50vh] flex-1" {...swipeHandlers}>
+      <div className="mt-19 flex flex-col gap-16 pb-38">
+        {missions.map((m) => (
+          <MissionCard key={m.id} {...m} />
+        ))}
+      </div>
+
+      {hasNextPage && (
+        <div ref={ref} className="flex justify-center py-20">
+          {isFetchingNextPage && <LoadingSpinner className="size-40" />}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/search/components/CategoryMissionList.tsx
+++ b/src/pages/search/components/CategoryMissionList.tsx
@@ -2,7 +2,10 @@ import { useNavigate } from "react-router-dom";
 import IcPlus from "@/assets/icons/ic_plus.svg?react";
 import { Button } from "@/components/common/button/Button";
 import MissionCard from "@/components/MissionCard";
-import { CATEGORY_ID_MAP, type MainCategory } from "@/mocks/search/mission";
+import {
+  CATEGORY_ID_MAP,
+  type MainCategory,
+} from "@/constants/missions/categories";
 import { useCategoryMissions } from "../hooks/useQuery/useCategoryMissions";
 
 interface CategoryMissionListProps {

--- a/src/pages/search/components/CategorySection.tsx
+++ b/src/pages/search/components/CategorySection.tsx
@@ -1,5 +1,8 @@
 import { Button } from "@/components/common/button/Button";
-import { MAIN_CATEGORIES, type MainCategory } from "@/mocks/search/mission";
+import {
+  MAIN_CATEGORIES,
+  type MainCategory,
+} from "@/constants/missions/categories";
 import { cn } from "@/utils/cn/cn";
 
 interface CategorySectionProps {
@@ -25,7 +28,7 @@ export default function CategorySection({
                 "body-4 shrink-0 grow rounded-sm px-16 py-8",
                 selectedCategory === category
                   ? "bg-moamoa-300 text-white"
-                  : "bg-moamoa-50 text-moamoa-300",
+                  : "bg-moamoa-50 text-moamoa-300"
               )}
             >
               {category}

--- a/src/pages/search/components/common/RecommendedMissionCard.tsx
+++ b/src/pages/search/components/common/RecommendedMissionCard.tsx
@@ -30,15 +30,18 @@ export default function RecommendedMissionCard({
         />
       </div>
 
-      <div className="mt-18 flex flex-wrap gap-4">
-        {keywords.map((keyword) => (
-          <span
-            key={keyword}
-            className="body-4 rounded-sm bg-moamoa-50 px-17 py-8 text-moamoa-500"
-          >
-            {keyword}
-          </span>
-        ))}
+      <div className="-mx-16 mt-18 overflow-x-auto">
+        <div className="flex gap-4 px-16">
+          {keywords.map((keyword) => (
+            <span
+              key={keyword}
+              className="body-4 shrink-0 rounded-sm bg-moamoa-50 px-17 py-8 text-moamoa-500"
+            >
+              {keyword}
+            </span>
+          ))}
+          <div className="w-16 shrink-0" />
+        </div>
       </div>
 
       <div className="mt-8 flex flex-col gap-4">

--- a/src/pages/search/hooks/useCategoryDetailState.ts
+++ b/src/pages/search/hooks/useCategoryDetailState.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  CATEGORY_ID_MAP,
+  type Category,
+  MAIN_CATEGORIES,
+  type MainCategory,
+  SUB_CATEGORIES,
+} from "@/constants/missions/categories";
+import { useCategorySwipe } from "./useCategorySwipe";
+
+const getInitialSubCategory = (
+  mainCategory: MainCategory,
+  subParam: string | null
+): Category => {
+  const subCategories = SUB_CATEGORIES[mainCategory] ?? [];
+
+  if (subParam) {
+    const found = subCategories.find((s) => s.name === subParam);
+    if (found) return found;
+  }
+
+  return subCategories[0] ?? { categoryId: 0, name: "" };
+};
+
+export const useCategoryDetailState = () => {
+  const [searchParams] = useSearchParams();
+  const mainParam = searchParams.get("main") || "";
+  const subParam = searchParams.get("sub");
+
+  const validMainCategory: MainCategory = MAIN_CATEGORIES.includes(
+    mainParam as MainCategory
+  )
+    ? (mainParam as MainCategory)
+    : "경제와 금융";
+
+  // 카테고리뷰 진입 시 생성한 seed를 계속 유지 (페이지 넘길 때 중복 방지용)
+  const seed = useRef(Date.now()).current;
+
+  const [selectedSubCategory, setSelectedSubCategory] = useState<Category>(() =>
+    getInitialSubCategory(validMainCategory, subParam)
+  );
+
+  useEffect(() => {
+    setSelectedSubCategory(getInitialSubCategory(validMainCategory, subParam));
+  }, [subParam, validMainCategory]);
+
+  const { selectedCategory, setSelectedCategory, swipeHandlers } =
+    useCategorySwipe(validMainCategory, (category) => {
+      const firstSub = SUB_CATEGORIES[category]?.[0];
+      if (firstSub) {
+        setSelectedSubCategory(firstSub);
+      }
+    });
+
+  const subCategories = SUB_CATEGORIES[selectedCategory] ?? [];
+  const categoryId = CATEGORY_ID_MAP[selectedCategory];
+
+  const handleSubCategoryClick = (name: string) => {
+    const subCat = subCategories.find((s) => s.name === name);
+    if (subCat) {
+      setSelectedSubCategory(subCat);
+    }
+  };
+
+  return {
+    selectedCategory,
+    setSelectedCategory,
+    selectedSubCategory,
+    subCategories,
+    categoryId,
+    seed,
+    swipeHandlers,
+    handleSubCategoryClick,
+  };
+};

--- a/src/pages/search/hooks/useCategorySwipe.ts
+++ b/src/pages/search/hooks/useCategorySwipe.ts
@@ -1,6 +1,9 @@
 import { useState } from "react";
+import {
+  MAIN_CATEGORIES,
+  type MainCategory,
+} from "@/constants/missions/categories";
 import { useSwipe } from "@/hooks/useSwipe";
-import { MAIN_CATEGORIES, type MainCategory } from "@/mocks/search/mission";
 
 export function useCategorySwipe(
   initialCategory: MainCategory = "경제와 금융",

--- a/src/pages/search/hooks/useCategorySwipe.ts
+++ b/src/pages/search/hooks/useCategorySwipe.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   MAIN_CATEGORIES,
   type MainCategory,
@@ -11,6 +11,12 @@ export function useCategorySwipe(
 ) {
   const [selectedCategory, setSelectedCategory] = useState(initialCategory);
   const currentIndex = MAIN_CATEGORIES.indexOf(selectedCategory);
+
+  useEffect(() => {
+    if (initialCategory !== selectedCategory) {
+      setSelectedCategory(initialCategory);
+    }
+  }, [initialCategory, selectedCategory]);
 
   const handleCategoryChange = (category: MainCategory) => {
     setSelectedCategory(category);

--- a/src/pages/search/hooks/useQuery/useCategoryMissionsInfinite.ts
+++ b/src/pages/search/hooks/useQuery/useCategoryMissionsInfinite.ts
@@ -1,0 +1,30 @@
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { getCategoryMissions } from "@/apis/missions/categories";
+
+interface UseCategoryMissionsInfiniteParams {
+  categoryId: number;
+  subcategoryId: number;
+  seed: number;
+}
+
+export const useCategoryMissionsInfinite = ({
+  categoryId,
+  subcategoryId,
+  seed,
+}: UseCategoryMissionsInfiniteParams) => {
+  return useSuspenseInfiniteQuery({
+    queryKey: ["missions", "category", categoryId, subcategoryId, seed],
+    queryFn: ({ pageParam }) =>
+      getCategoryMissions({
+        categoryId,
+        subcategoryId,
+        page: pageParam,
+        size: 10,
+        seed,
+      }),
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      return lastPage.hasNext ? lastPageParam + 1 : undefined;
+    },
+    initialPageParam: 0,
+  });
+};

--- a/src/pages/search/views/CategoryDetailView.tsx
+++ b/src/pages/search/views/CategoryDetailView.tsx
@@ -1,60 +1,22 @@
-import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
-import MissionCard from "@/components/MissionCard";
-import {
-  MAIN_CATEGORIES,
-  type MainCategory,
-  MOCK_DETAIL_MISSIONS,
-  MOCK_SUB_CATEGORIES,
-} from "@/mocks/search/mission";
+import { Suspense } from "react";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { MAIN_CATEGORIES } from "@/constants/missions/categories";
 import CategoryButton from "../components/CategoryButton";
+import CategoryMissionInfiniteList from "../components/CategoryMissionInfiniteList";
 import SubCategoryButton from "../components/SubCategoryButton";
-import { useCategorySwipe } from "../hooks/useCategorySwipe";
+import { useCategoryDetailState } from "../hooks/useCategoryDetailState";
 
 export default function CategoryDetailView() {
-  const [searchParams] = useSearchParams();
-  const mainParam = searchParams.get("main") || "";
-
-  const validMainCategory: MainCategory = MAIN_CATEGORIES.includes(
-    mainParam as MainCategory
-  )
-    ? (mainParam as MainCategory)
-    : "경제와 금융";
-
-  const initialSub =
-    searchParams.get("sub") ||
-    MOCK_SUB_CATEGORIES[validMainCategory]?.[0]?.name ||
-    "";
-
-  const [subCategory, setSubCategory] = useState(initialSub);
-
-  useEffect(() => {
-    const newSub =
-      searchParams.get("sub") ||
-      MOCK_SUB_CATEGORIES[validMainCategory]?.[0]?.name ||
-      "";
-    setSubCategory(newSub);
-  }, [searchParams, validMainCategory]);
-
-  const { selectedCategory, setSelectedCategory, swipeHandlers } =
-    useCategorySwipe(validMainCategory, (category) => {
-      setSubCategory(MOCK_SUB_CATEGORIES[category]?.[0]?.name ?? "");
-    });
-
-  const subCategories = MOCK_SUB_CATEGORIES[selectedCategory] ?? [];
-
-  // TODO: 카테고리별 미션 조회 API 연결 시 수정
-  const missions = (MOCK_DETAIL_MISSIONS[selectedCategory] ?? [])
-    .filter((m) => m.category === subCategory)
-    .map((m) => ({
-      id: m.missionId,
-      title: m.title,
-      keywords: m.keywords,
-      minute: m.durationMinutes,
-      category: m.category,
-      quizCount: m.quizCount,
-      isLiked: m.isScrapped,
-    }));
+  const {
+    selectedCategory,
+    setSelectedCategory,
+    selectedSubCategory,
+    subCategories,
+    categoryId,
+    seed,
+    swipeHandlers,
+    handleSubCategoryClick,
+  } = useCategoryDetailState();
 
   return (
     <>
@@ -79,21 +41,31 @@ export default function CategoryDetailView() {
             <SubCategoryButton
               key={sub.categoryId}
               category={sub}
-              isSelected={subCategory === sub.name}
-              onClick={setSubCategory}
+              isSelected={selectedSubCategory.categoryId === sub.categoryId}
+              onClick={handleSubCategoryClick}
             />
           ))}
           <div className="w-15 shrink-0 min-[400px]:hidden" />
         </div>
       </div>
 
-      <div className="min-h-[50vh] flex-1" {...swipeHandlers}>
-        <div className="mt-19 flex flex-col gap-16 pb-38">
-          {missions.map((m) => (
-            <MissionCard key={m.id} {...m} />
-          ))}
-        </div>
-      </div>
+      {selectedSubCategory.categoryId !== 0 && (
+        <Suspense
+          fallback={
+            <div className="mt-30 flex items-center justify-center">
+              <LoadingSpinner className="size-60" />
+            </div>
+          }
+        >
+          <CategoryMissionInfiniteList
+            key={`${categoryId}-${selectedSubCategory.categoryId}`}
+            categoryId={categoryId}
+            subcategoryId={selectedSubCategory.categoryId}
+            seed={seed}
+            swipeHandlers={swipeHandlers}
+          />
+        </Suspense>
+      )}
     </>
   );
 }


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #68 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 인증 로직 무한루프 수정                                                                                          
  - 비로그인 상태에서 출석체크 API 무한 호출되던 문제 해결                                                                   
  - AuthGuard에 useAuth 통합하여 인증 로직 단일화                                                                            
  - interceptor의 강제 리로드 제거                                                                                           
                                                                                                                             
 - 카테고리 상수 분리                                                                                               
  - mocks → constants로 이동 (MAIN_CATEGORIES, CATEGORY_ID_MAP, SUB_CATEGORIES)                                                                                                                                        
                                                                                                                             
- 무한스크롤 구현                                                                                                  
  - 카테고리별 미션 무한스크롤 추가                                                                                          
  - seed 파라미터로 페이지 간 순서 일관성 보장                                                                               
  - intersection observer 사용                                                                              
                                                                                                                                                
- CategoryDetailView 리팩토링: 상태로직 훅 분리

- 키워드 가로 스크롤 UX 개선                                                                                       
  - 추천 미션 카드 키워드 스크롤 시 오른쪽 여백 추가                                                                     
  

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|내용|화면|
|---|---|
|목데이터 넣은 화면|![화면 기록 2026-02-02 오후 11 51 27](https://github.com/user-attachments/assets/ee226d28-e549-4e32-99ed-900a4a569c0b)|


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
seed 파라미터: 카테고리 진입 시 생성, 세션 유지
가로스크롤 개선 영상은 없습니다.. 다른 서브 카테고리 영역과 같은 로직 사용했습니다.
데이터가 없는 관계로 목데이터 입니다. 200 뜨는거 확인 후 목데이터로 똑같이 시연했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리/하위카테고리 정의 및 검색 상태 관리 훅 추가
  * 카테고리별 미션 무한 스크롤 목록 추가
  * 미션용 목업 데이터 및 추천 미션 추가

* **UI 개선**
  * 미션 키워드 가로 스크롤 레이아웃 적용
  * 인증 상태 로딩 스피너 표시 개선

* **버그 수정**
  * 토큰 갱신 실패 시 자동 로그인 리다이렉트 제거

* **의존성**
  * react-intersection-observer 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->