### PR TITLE
Feat: 설정페이지 나의 문의 상세 조회 UI

### DIFF
--- a/src/pages/settings/components/inquiry/InquiryDetailPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryDetailPage.tsx
@@ -1,8 +1,9 @@
 ﻿import { useMemo } from "react";
 import { useParams } from "react-router-dom";
+import IcReply from "@/assets/icons/ic_reply.svg?react";
 import Header from "@/components/common/header/Header";
-import StatusPill from "./StatusPill";
 import { mockInquiryDetail } from "../../mocks/inquiry/inquiry.mock";
+import StatusPill from "./StatusPill";
 
 // TODO(API 연결 시): GET /inquiries/{inquiryId} 결과로 교체
 
@@ -29,13 +30,34 @@ export default function InquiryDetailPage() {
             </span>
           </div>
 
-          <p className="mt-20 heading-2 w-full truncate text-black">
+          <p className="heading-2 mt-20 w-full truncate text-black">
             {data.title}
           </p>
 
-          <p className="mt-16 body-4 w-full text-black">
-            {data.content}
-          </p>
+          <p className="body-4 mt-16 w-full text-black">{data.content}</p>
+
+          <div
+            className="mt-23 mb-23 h-2 w-full rounded-md"
+            style={{ background: "var(--MOAMOA-G-200, #EEE)" }}
+          />
+
+          <div className="flex w-full flex-col items-start gap-20 self-stretch">
+            <div className="flex items-center gap-12">
+              <IcReply className="h-24 w-24" aria-hidden />
+              <span className="body-4 text-center text-black">담당자 OOO</span>
+            </div>
+
+            <div className="flex items-start gap-20">
+              <div className="h-139 w-139 rounded-lg bg-moamoa-50" />
+              <div className="h-139 w-139 rounded-lg bg-moamoa-50" />
+            </div>
+
+            <p className="body-4 text-black">
+              {data.answerStatus === "COMPLETED"
+                ? "답변 내용이 표시됩니다."
+                : "아직 답변이 등록되지 않았어요."}
+            </p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🚀 관련 이슈

- close #85 

## 🔑 작업 내용

관리자 답변 등록 UI 구현했습니다! 

## 📷 스크린샷

<img width="403" height="826" alt="스크린샷 2026-02-05 220406" src="https://github.com/user-attachments/assets/71014a2f-be16-4a6e-b74a-0eb90a1b8fe2" />

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 문의 상세 페이지에 담당자 정보 및 아이콘과 함께 새로운 답변 영역이 추가되었습니다.
  * 답변 상태에 따라 동적으로 메시지가 변경됩니다.
  * 사용자에게 답변 등록 상태를 명확하게 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->