### PR TITLE
Feat: 문의하기 약관 동의 페이지 UI 구현

### DIFF
--- a/src/pages/settings/components/common/BottomActionBar.tsx
+++ b/src/pages/settings/components/common/BottomActionBar.tsx
@@ -1,13 +1,20 @@
 import type { ReactNode } from "react";
 import { Button } from "@/components/common/button/Button";
+import { cn } from "@/utils/cn/cn";
 
 type Props = {
   label: string;
   leftIcon?: ReactNode;
   onClick?: () => void;
+  buttonClassName?: string;
 };
 
-export default function BottomActionBar({ label, leftIcon, onClick }: Props) {
+export default function BottomActionBar({
+  label,
+  leftIcon,
+  onClick,
+  buttonClassName,
+}: Props) {
   return (
     <div className="fixed right-0 bottom-0 left-0 z-20 bg-[#FAFAFA] shadow-[0_-8px_50px_3px_rgba(0,0,0,0.10)]">
       <div className="flex h-98 w-full items-center justify-center px-25 pt-8 pb-[calc(42px+env(safe-area-inset-bottom))]">
@@ -15,7 +22,10 @@ export default function BottomActionBar({ label, leftIcon, onClick }: Props) {
           type="button"
           onClick={onClick}
           leftIcon={leftIcon}
-          className="heading-5 flex h-48 w-full items-center justify-center rounded-lg bg-moamoa-300 text-white"
+          className={cn(
+            "heading-5 flex h-48 w-full items-center justify-center rounded-lg bg-moamoa-300 text-white",
+            buttonClassName
+          )}
         >
           {label}
         </Button>

--- a/src/pages/settings/components/common/BottomActionBar.tsx
+++ b/src/pages/settings/components/common/BottomActionBar.tsx
@@ -7,6 +7,7 @@ type Props = {
   leftIcon?: ReactNode;
   onClick?: () => void;
   buttonClassName?: string;
+  disabled?: boolean;
 };
 
 export default function BottomActionBar({
@@ -14,6 +15,7 @@ export default function BottomActionBar({
   leftIcon,
   onClick,
   buttonClassName,
+  disabled = false,
 }: Props) {
   return (
     <div className="fixed right-0 bottom-0 left-0 z-20 bg-[#FAFAFA] shadow-[0_-8px_50px_3px_rgba(0,0,0,0.10)]">
@@ -22,6 +24,7 @@ export default function BottomActionBar({
           type="button"
           onClick={onClick}
           leftIcon={leftIcon}
+          disabled={disabled}
           className={cn(
             "heading-5 flex h-48 w-full items-center justify-center rounded-lg bg-moamoa-300 text-white",
             buttonClassName

--- a/src/pages/settings/components/inquiry/InquiryConsentPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryConsentPage.tsx
@@ -1,0 +1,99 @@
+﻿import { useState } from "react";
+import IcCheck from "@/assets/icons/ic_check.svg?react";
+import { Button } from "@/components/common/button/Button";
+import Header from "@/components/common/header/Header";
+import BottomActionBar from "@/pages/settings/components/common/BottomActionBar";
+
+export default function InquiryConsentPage() {
+  const [isAgreed, setIsAgreed] = useState(false);
+
+  return (
+    <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-white">
+      <Header title="이용 약관 동의" property="common" />
+
+      <div className="-mx-[25px] mt-[14px] h-[2px] bg-gray-200" />
+
+      <div className="flex min-h-0 w-full flex-1 flex-col items-center overflow-hidden">
+        <div className="mt-[34px] w-full">
+          <Button
+            type="button"
+            onClick={() => setIsAgreed((prev) => !prev)}
+            className={[
+              "inline-flex w-full items-center justify-start rounded-[12px] py-[14px] pr-[116px] pl-[17px]",
+              isAgreed ? "bg-moamoa-50" : "bg-gray-100",
+            ].join(" ")}
+          >
+            <IcCheck
+              className="h-[24px] w-[24px]"
+              style={{
+                color: isAgreed
+                  ? "var(--color-positive, #2664ED)"
+                  : "var(--color-gray-500, #9E9E9E)",
+              }}
+              aria-hidden
+            />
+            <span className="body-2 ml-[75px] whitespace-nowrap text-black">
+              네, 동의합니다
+            </span>
+          </Button>
+        </div>
+
+        <div className="mt-[34px] flex min-h-0 w-full flex-1 flex-col items-start gap-[13px] pb-[140px]">
+          <div className="flex items-center">
+            <IcCheck
+              className="h-[24px] w-[24px]"
+              style={{
+                color: isAgreed
+                  ? "var(--color-positive, #2664ED)"
+                  : "var(--color-gray-500, #9E9E9E)",
+              }}
+              aria-hidden
+            />
+            <span className="heading-6 ml-[7px] text-black">
+              개인정보 수집 및 이용 동의
+            </span>
+            <span className="body-2 ml-[6px] text-moamoa-400">(필수)</span>
+          </div>
+
+          <div className="flex max-h-[456px] min-h-0 w-full flex-1 flex-col items-start justify-start overflow-y-auto rounded-[12px] border border-gray-400 bg-white px-[15px] pt-[15px] pb-[15px]">
+            <div className="body-4 w-full whitespace-pre-line text-gray-700">
+              (주)모아모아는 서비스 제공을 위하여
+              {"\n"}아래와 같이 개인정보를 수집·이용하고자 합니다.
+              {"\n"}내용을 자세히 읽으신 후 동의해 주시기 바랍니다.
+              {"\n\n"}1. 수집 및 이용 목적
+              {"\n"}• 회원 가입 및 관리: 본인 식별, 회원 자격 유지, 서비스 이용
+              의사 확인
+              {"\n"}• 서비스 제공: 미션 수행 기록 저장, 리워드(도토리) 적립 및
+              사용
+              {"\n"}• 부정 이용 방지: 비정상적인 미션 수행(매크로 등) 탐지 및
+              제재
+              {"\n\n"}2. 수집하는 항목
+              {"\n"}• (필수) 이메일, 비밀번호, 닉네임
+              {"\n"}• (필수 ·자동수집) 기기식별값(ADID/IDFA), 서비스 이용 기록,
+              접속 로그
+              {"\n"}
+              {"\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0"}• ※
+              기기식별값은 중복 가입 및 보상 부정 수급 방지를 위해 필수적으로
+              수집합니다.
+              {"\n\n"}3. 보유 및 이용 기간
+              {"\n"}• 회원 탈퇴 시까지
+              {"\n"}• 단, 부정 이용 방지를 위해 기기식별값 및 불량 이용 기록은
+              탈퇴 후 1년간 보관 후 파기합니다.
+              {"\n\n"}4. 동의를 거부할 권리
+              {"\n"}• 귀하는 개인정보 수집 및 이용에 대한 동의를 거부할 권리가
+              있습니다.
+              {"\n"}• 단, 동의를 거부할 경우 회원가입 및 미션 수행, 보상 지급 등
+              서비스 이용이 불가능합니다.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <BottomActionBar
+        label="동의합니다"
+        onClick={() => setIsAgreed((prev) => !prev)}
+        buttonClassName={isAgreed ? "bg-moamoa-300" : "bg-gray-300"}
+      />
+    </div>
+  );
+}

--- a/src/pages/settings/components/inquiry/InquiryConsentPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryConsentPage.tsx
@@ -1,13 +1,16 @@
 ﻿import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import IcCheck from "@/assets/icons/ic_check.svg?react";
 import { Button } from "@/components/common/button/Button";
 import Header from "@/components/common/header/Header";
 import BottomActionBar from "@/pages/settings/components/common/BottomActionBar";
+import type { InquiryDraft } from "../../types/inquiry.type";
 
 export default function InquiryConsentPage() {
   const [isAgreed, setIsAgreed] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+  const draft = (location.state as { draft?: InquiryDraft } | null)?.draft;
 
   return (
     <div className="flex h-[calc(100dvh-98px-42px-env(safe-area-inset-bottom))] w-full flex-col overflow-hidden bg-white">
@@ -16,7 +19,7 @@ export default function InquiryConsentPage() {
         property="common"
         onBack={() =>
           navigate("/settings/inquiry", {
-            state: { consentAgreed: isAgreed },
+            state: { consentAgreed: isAgreed, draft },
             replace: true,
           })
         }
@@ -108,7 +111,7 @@ export default function InquiryConsentPage() {
           const next = true;
           setIsAgreed(true);
           navigate("/settings/inquiry", {
-            state: { consentAgreed: next },
+            state: { consentAgreed: next, draft },
             replace: true,
           });
         }}

--- a/src/pages/settings/components/inquiry/InquiryConsentPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryConsentPage.tsx
@@ -1,4 +1,5 @@
 ﻿import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import IcCheck from "@/assets/icons/ic_check.svg?react";
 import { Button } from "@/components/common/button/Button";
 import Header from "@/components/common/header/Header";
@@ -6,10 +7,20 @@ import BottomActionBar from "@/pages/settings/components/common/BottomActionBar"
 
 export default function InquiryConsentPage() {
   const [isAgreed, setIsAgreed] = useState(false);
+  const navigate = useNavigate();
 
   return (
-    <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-white">
-      <Header title="이용 약관 동의" property="common" />
+    <div className="flex h-[calc(100dvh-98px-42px-env(safe-area-inset-bottom))] w-full flex-col overflow-hidden bg-white">
+      <Header
+        title="이용 약관 동의"
+        property="common"
+        onBack={() =>
+          navigate("/settings/inquiry", {
+            state: { consentAgreed: isAgreed },
+            replace: true,
+          })
+        }
+      />
 
       <div className="-mx-[25px] mt-[14px] h-[2px] bg-gray-200" />
 
@@ -38,7 +49,7 @@ export default function InquiryConsentPage() {
           </Button>
         </div>
 
-        <div className="mt-[34px] flex min-h-0 w-full flex-1 flex-col items-start gap-[13px] pb-[140px]">
+        <div className="mt-[34px] flex min-h-0 w-full flex-1 flex-col items-start gap-[13px]">
           <div className="flex items-center">
             <IcCheck
               className="h-[24px] w-[24px]"
@@ -74,7 +85,8 @@ export default function InquiryConsentPage() {
               {"\n"}
               {"\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0"}• ※
               기기식별값은 중복 가입 및 보상 부정 수급 방지를 위해 필수적으로
-              수집합니다.
+              {"\n"}
+              {"\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0"}수집합니다.
               {"\n\n"}3. 보유 및 이용 기간
               {"\n"}• 회원 탈퇴 시까지
               {"\n"}• 단, 부정 이용 방지를 위해 기기식별값 및 불량 이용 기록은
@@ -91,7 +103,15 @@ export default function InquiryConsentPage() {
 
       <BottomActionBar
         label="동의합니다"
-        onClick={() => setIsAgreed((prev) => !prev)}
+        disabled={!isAgreed}
+        onClick={() => {
+          const next = true;
+          setIsAgreed(true);
+          navigate("/settings/inquiry", {
+            state: { consentAgreed: next },
+            replace: true,
+          });
+        }}
         buttonClassName={isAgreed ? "bg-moamoa-300" : "bg-gray-300"}
       />
     </div>

--- a/src/pages/settings/components/inquiry/InquiryConsentRow.tsx
+++ b/src/pages/settings/components/inquiry/InquiryConsentRow.tsx
@@ -2,14 +2,25 @@
 
 type Props = {
   onViewPolicy?: () => void;
+  agreed?: boolean;
 };
 
-export default function InquiryConsentRow({ onViewPolicy }: Props) {
+export default function InquiryConsentRow({ onViewPolicy, agreed = false }: Props) {
   return (
     <div className="flex w-full items-center justify-between pb-41">
       <div className="flex items-center gap-8">
-        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-400 p-1">
-          <IcCheck className="h-13 w-13 text-white" />
+        <div
+          className={[
+            "flex h-16 w-16 items-center justify-center rounded-full p-1",
+            agreed ? "bg-moamoa-50" : "bg-gray-400",
+          ].join(" ")}
+        >
+          <IcCheck
+            className={[
+              "h-13 w-13",
+              agreed ? "text-moamoa-400" : "text-white",
+            ].join(" ")}
+          />
         </div>
         <span className="body-4 text-center text-gray-600">
           (필수) 개인정보 수집・이용에 대한 안내

--- a/src/pages/settings/components/inquiry/InquiryPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryPage.tsx
@@ -1,5 +1,5 @@
-﻿import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+﻿import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import Header from "@/components/common/header/Header";
 import type { TabKey } from "../../types/inquiry.type";
 import BottomActionBar from "../common/BottomActionBar";
@@ -10,6 +10,13 @@ import InquiryWriteForm from "./InquiryWriteForm";
 export default function InquiryPage() {
   const navigate = useNavigate();
   const [tab, setTab] = useState<TabKey>("write");
+  const [agreed, setAgreed] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    const next = (location.state as { consentAgreed?: boolean } | null)?.consentAgreed;
+    if (typeof next === "boolean") setAgreed(next);
+  }, [location.state]);
 
   return (
     <div className="min-h-screen w-full bg-white">
@@ -27,7 +34,7 @@ export default function InquiryPage() {
 
       <div className="flex w-full flex-col items-center">
         {tab === "write" ? (
-          <InquiryWriteForm />
+          <InquiryWriteForm agreed={agreed} />
         ) : (
           <InquiryList onSelect={(id) => navigate(`/settings/inquiry/${id}`)} />
         )}
@@ -36,7 +43,10 @@ export default function InquiryPage() {
       {tab === "write" && (
         <BottomActionBar
           label="문의 접수"
+          disabled={!agreed}
+          buttonClassName={agreed ? "bg-moamoa-300" : "bg-gray-300"}
           onClick={() => {
+            if (!agreed) return;
             // TODO: 문의 접수 API 호출 로직 구현
           }}
         />

--- a/src/pages/settings/components/inquiry/InquiryPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryPage.tsx
@@ -1,7 +1,7 @@
 ﻿import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Header from "@/components/common/header/Header";
-import type { TabKey } from "../../types/inquiry.type";
+import type { InquiryDraft, TabKey } from "../../types/inquiry.type";
 import BottomActionBar from "../common/BottomActionBar";
 import InquiryList from "./InquiryList";
 import InquiryTabs from "./InquiryTabs";
@@ -11,11 +11,24 @@ export default function InquiryPage() {
   const navigate = useNavigate();
   const [tab, setTab] = useState<TabKey>("write");
   const [agreed, setAgreed] = useState(false);
+  const [draft, setDraft] = useState<InquiryDraft>({
+    category: null,
+    title: "",
+    content: "",
+    images: [],
+  });
   const location = useLocation();
 
   useEffect(() => {
-    const next = (location.state as { consentAgreed?: boolean } | null)?.consentAgreed;
-    if (typeof next === "boolean") setAgreed(next);
+    const state = location.state as
+      | { consentAgreed?: boolean; draft?: InquiryDraft }
+      | null;
+    if (typeof state?.consentAgreed === "boolean") {
+      setAgreed(state.consentAgreed);
+    }
+    if (state?.draft) {
+      setDraft(state.draft);
+    }
   }, [location.state]);
 
   return (
@@ -34,7 +47,7 @@ export default function InquiryPage() {
 
       <div className="flex w-full flex-col items-center">
         {tab === "write" ? (
-          <InquiryWriteForm agreed={agreed} />
+          <InquiryWriteForm agreed={agreed} draft={draft} setDraft={setDraft} />
         ) : (
           <InquiryList onSelect={(id) => navigate(`/settings/inquiry/${id}`)} />
         )}

--- a/src/pages/settings/components/inquiry/InquiryWriteForm.tsx
+++ b/src/pages/settings/components/inquiry/InquiryWriteForm.tsx
@@ -11,11 +11,15 @@ const MAX_CONTENT = 2000;
 const MAX_IMAGES = 5;
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
 
+type Props = {
+  agreed: boolean;
+};
+
 function clamp(n: number, max: number) {
   return Math.min(max, Math.max(0, n));
 }
 
-export default function InquiryWriteForm() {
+export default function InquiryWriteForm({ agreed }: Props) {
   const fileInputId = useId();
   const navigate = useNavigate();
   const [draft, setDraft] = useState<InquiryDraft>({
@@ -81,6 +85,7 @@ export default function InquiryWriteForm() {
       <div className="mt-67 w-full">
         <InquiryConsentRow
           onViewPolicy={() => navigate("/settings/inquiry/consent")}
+          agreed={agreed}
         />
       </div>
     </div>

--- a/src/pages/settings/components/inquiry/InquiryWriteForm.tsx
+++ b/src/pages/settings/components/inquiry/InquiryWriteForm.tsx
@@ -1,4 +1,5 @@
 ﻿import { useId, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import InquiryAttachmentSection from "./InquiryAttachmentSection";
 import InquiryCategorySection from "./InquiryCategorySection";
 import InquiryConsentRow from "./InquiryConsentRow";
@@ -16,6 +17,7 @@ function clamp(n: number, max: number) {
 
 export default function InquiryWriteForm() {
   const fileInputId = useId();
+  const navigate = useNavigate();
   const [draft, setDraft] = useState<InquiryDraft>({
     category: null,
     title: "",
@@ -77,7 +79,9 @@ export default function InquiryWriteForm() {
       />
 
       <div className="mt-67 w-full">
-        <InquiryConsentRow onViewPolicy={() => {}} />
+        <InquiryConsentRow
+          onViewPolicy={() => navigate("/settings/inquiry/consent")}
+        />
       </div>
     </div>
   );

--- a/src/pages/settings/components/inquiry/InquiryWriteForm.tsx
+++ b/src/pages/settings/components/inquiry/InquiryWriteForm.tsx
@@ -1,4 +1,4 @@
-﻿import { useId, useMemo, useState } from "react";
+﻿import { useId, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import InquiryAttachmentSection from "./InquiryAttachmentSection";
 import InquiryCategorySection from "./InquiryCategorySection";
@@ -13,21 +13,17 @@ const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
 
 type Props = {
   agreed: boolean;
+  draft: InquiryDraft;
+  setDraft: React.Dispatch<React.SetStateAction<InquiryDraft>>;
 };
 
 function clamp(n: number, max: number) {
   return Math.min(max, Math.max(0, n));
 }
 
-export default function InquiryWriteForm({ agreed }: Props) {
+export default function InquiryWriteForm({ agreed, draft, setDraft }: Props) {
   const fileInputId = useId();
   const navigate = useNavigate();
-  const [draft, setDraft] = useState<InquiryDraft>({
-    category: null,
-    title: "",
-    content: "",
-    images: [],
-  });
 
   const titleCount = useMemo(() => draft.title.length, [draft.title]);
   const contentCount = useMemo(() => draft.content.length, [draft.content]);
@@ -84,7 +80,9 @@ export default function InquiryWriteForm({ agreed }: Props) {
 
       <div className="mt-67 w-full">
         <InquiryConsentRow
-          onViewPolicy={() => navigate("/settings/inquiry/consent")}
+          onViewPolicy={() =>
+            navigate("/settings/inquiry/consent", { state: { draft } })
+          }
           agreed={agreed}
         />
       </div>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -12,6 +12,7 @@ import AccountInfoPage from "@/pages/settings/AccountInfoPage";
 import FaqPage from "@/pages/settings/components/FaqPage";
 import Interests from "@/pages/settings/components/Interests";
 import InquiryDetailPage from "@/pages/settings/components/inquiry/InquiryDetailPage";
+import InquiryConsentPage from "@/pages/settings/components/inquiry/InquiryConsentPage";
 import InquiryPage from "@/pages/settings/components/inquiry/InquiryPage";
 import TargetMissionCount from "@/pages/settings/components/TargetMissionCount";
 import PasswordChangePage from "@/pages/settings/PasswordChangePage";
@@ -113,6 +114,11 @@ const routes: (RouteObject & { handle?: RouteHandle })[] = [
       {
         path: "/settings/inquiry",
         element: <InquiryPage />,
+        handle: { hideBottomNav: true },
+      },
+      {
+        path: "/settings/inquiry/consent",
+        element: <InquiryConsentPage />,
         handle: { hideBottomNav: true },
       },
       {


### PR DESCRIPTION
## 🚀 관련 이슈

- close #90 

## 🔑 작업 내용

문의하기 약관 동의 페이지 UI 구현했습니다!


## 📷 스크린샷
<img width="459" height="825" alt="스크린샷 2026-02-06 021139" src="https://github.com/user-attachments/assets/c6f31278-5abb-4a18-9942-8061e9693458" />
<img width="459" height="830" alt="스크린샷 2026-02-06 021147" src="https://github.com/user-attachments/assets/b6607c52-c8d8-43e7-8016-5494c5b33b2c" />
<img width="946" height="826" alt="스크린샷 2026-02-06 021157" src="https://github.com/user-attachments/assets/5e7872e1-d9f5-4d42-b8d5-10ec84ceee7e" />

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

음 약관 페이지에서 상단 버튼을 눌러야 하단 액션바가 활성화가 되고, 하단 액션바 누르면 전문보기 체크 아이콘이 활성화 되면서 
아래 문의 접수 버튼까지 활성화 되게 했습니다! 확인해주시고 수정할 거 알려주세요 !!

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 문의 작성 전에 개인정보 처리방침 동의 단계 추가(동의 페이지 및 라우트)
  * 동의 페이지에서 정책 전문 확인 및 토글로 동의 처리 가능
* **개선**
  * 사용자의 동의 상태에 따라 다음 단계 버튼 활성화/비활성화 및 시각적 피드백 강화
  * 하단 작업 표시줄의 버튼 스타일 및 비활성화 제어를 위한 커스터마이징 옵션 추가
* **사용성**
  * 이전 화면으로 돌아갈 때 동의 상태와 작성 중 초안이 보존되어 복원됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->