### PR TITLE
Feat: 홈화면 자투리 시간 별 오늘의 미션 추천 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-error-boundary": "^6.1.0",
     "react-intersection-observer": "^10.0.2",
     "react-router-dom": "^7.11.0",
     "tailwind-merge": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
+      react-error-boundary:
+        specifier: ^6.1.0
+        version: 6.1.0(react@19.2.3)
       react-intersection-observer:
         specifier: ^10.0.2
         version: 10.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2078,6 +2081,11 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-error-boundary@6.1.0:
+    resolution: {integrity: sha512-02k9WQ/mUhdbXir0tC1NiMesGzRPaCsJEWU/4bcFrbY1YMZOtHShtZP6zw0SJrBWA/31H0KT9/FgdL8+sPKgHA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react-intersection-observer@10.0.2:
     resolution: {integrity: sha512-lAMzxVWrBko6SLd1jx6l84fVrzJu91hpxHlvD2as2Wec9mDCjdYXwc5xNOFBchpeBir0Y7AGBW+C/AYMa7CSFg==}
@@ -4581,6 +4589,10 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-error-boundary@6.1.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-intersection-observer@10.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/components/AsyncBoundary.tsx
+++ b/src/components/AsyncBoundary.tsx
@@ -1,0 +1,54 @@
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { type ReactNode, Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { Button } from "@/components/common/button/Button";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+
+interface AsyncBoundaryProps {
+  children: ReactNode;
+  loadingFallback?: ReactNode;
+  errorFallback?: ReactNode;
+}
+
+function DefaultLoadingFallback() {
+  return (
+    <div className="flex h-[50vh] items-center justify-center">
+      <LoadingSpinner className="size-100" />
+    </div>
+  );
+}
+
+export default function AsyncBoundary({
+  children,
+  loadingFallback,
+  errorFallback,
+}: AsyncBoundaryProps) {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) =>
+            errorFallback ?? (
+              <div className="flex h-[50vh] flex-col items-center justify-center gap-16">
+                <p className="body-1 text-gray-500">
+                  데이터를 불러오는데 실패했어요
+                </p>
+                <Button
+                  onClick={resetErrorBoundary}
+                  className="rounded-lg bg-moamoa-300 px-20 py-10 text-white"
+                >
+                  다시 시도
+                </Button>
+              </div>
+            )
+          }
+        >
+          <Suspense fallback={loadingFallback ?? <DefaultLoadingFallback />}>
+            {children}
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}

--- a/src/components/MissionCard.tsx
+++ b/src/components/MissionCard.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/common/button/Button";
 import { cn } from "@/utils/cn/cn";
 
 interface MissionCardProps {
+  id: number;
   title: string;
   keywords: string[];
   minute: number;
@@ -14,6 +15,7 @@ interface MissionCardProps {
 }
 
 export default function MissionCard({
+  id,
   title,
   keywords,
   minute,

--- a/src/components/MissionCard.tsx
+++ b/src/components/MissionCard.tsx
@@ -15,7 +15,7 @@ interface MissionCardProps {
 }
 
 export default function MissionCard({
-  id,
+  id: _id,
   title,
   keywords,
   minute,

--- a/src/hooks/attendance/useAttendanceCheck.ts
+++ b/src/hooks/attendance/useAttendanceCheck.ts
@@ -8,8 +8,7 @@ import type { ApiError } from "@/types/api/api";
 import { attendanceCache } from "@/utils/attendance/attendance";
 
 export const useAttendanceCheck = () => {
-  const { setShowModal, setAttendanceData, attendanceData } =
-    useAttendanceStore();
+  const { setShowModal, setAttendanceData } = useAttendanceStore();
 
   const checkMutation = useMutation({
     mutationFn: checkAttendance,
@@ -40,8 +39,10 @@ export const useAttendanceCheck = () => {
   });
 
   const handleCheckAttendance = async () => {
+    const currentAttendanceData = useAttendanceStore.getState().attendanceData;
+
     // 이미 오늘 체크했지만 store에 데이터가 없는 경우 (앱 재시작)
-    if (attendanceCache.hasCheckedToday() && !attendanceData) {
+    if (attendanceCache.hasCheckedToday() && !currentAttendanceData) {
       try {
         const response = await getAttendanceStreak();
         setAttendanceData({

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import squirrelDefault from "@/assets/icons/home/character/squirrel_default.svg";
 import { useAttendanceStore } from "@/store/attendance/attendance";
 import { getWeeklyAttendance } from "@/utils/attendance/attendance";
@@ -14,9 +15,13 @@ import { useBottomSheet } from "./hooks/useBottomSheet";
 
 const HomePage = () => {
   useBgm("/audio/bgm.mp3");
+  const navigate = useNavigate();
   const [acornCount] = useState(13);
-  const [, setSelectedTime] = useState<number | null>(null);
   const nickname = "사용자";
+
+  const handleTimeSelect = (time: number) => {
+    navigate(`/today-mission?time=${time}`);
+  };
 
   const {
     activeCustomization,
@@ -46,7 +51,7 @@ const HomePage = () => {
 
       {!activeCustomization && (
         <div className="mt-17 mb-21 flex justify-center">
-          <QuestionBox nickname={nickname} onTimeSelect={setSelectedTime} />
+          <QuestionBox nickname={nickname} onTimeSelect={handleTimeSelect} />
         </div>
       )}
 

--- a/src/pages/today-mission/TodayMissionListView.tsx
+++ b/src/pages/today-mission/TodayMissionListView.tsx
@@ -1,10 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Suspense } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import IcLeft from "@/assets/icons/ic_left.svg?react";
 import IcReload from "@/assets/icons/ic_reload.svg?react";
+import AsyncBoundary from "@/components/AsyncBoundary";
 import { Button } from "@/components/common/button/Button";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import TodayMissionList from "./components/TodayMissionList";
 
 export default function TodayMissionListView() {
@@ -44,15 +43,9 @@ export default function TodayMissionListView() {
         </Button>
       </div>
 
-      <Suspense
-        fallback={
-          <div className="flex h-[50vh] items-center justify-center">
-            <LoadingSpinner className="size-100" />
-          </div>
-        }
-      >
+      <AsyncBoundary>
         <TodayMissionList />
-      </Suspense>
+      </AsyncBoundary>
     </div>
   );
 }

--- a/src/pages/today-mission/TodayMissionListView.tsx
+++ b/src/pages/today-mission/TodayMissionListView.tsx
@@ -1,57 +1,24 @@
-import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import IcLeft from "@/assets/icons/ic_left.svg?react";
 import IcReload from "@/assets/icons/ic_reload.svg?react";
 import { Button } from "@/components/common/button/Button";
-import MissionCard from "@/components/MissionCard";
-
-const ITEMS_PER_PAGE = 10;
-
-// TODO: 홈 화면 추천 미션 API 연결 시 수정 필요
-const TEMP_MISSIONS = [
-  {
-    id: 1,
-    title: "임시 미션",
-    keywords: ["임시"],
-    minute: 10,
-    category: "임시",
-    quizCount: 3,
-    isLiked: false,
-  },
-];
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import TodayMissionList from "./components/TodayMissionList";
 
 export default function TodayMissionListView() {
   const navigate = useNavigate();
-  const [missions] = useState(TEMP_MISSIONS);
-  const [displayedCount, setDisplayedCount] = useState(ITEMS_PER_PAGE);
-  const observerTarget = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const time = searchParams.get("time");
+  const timeValue = time ? Number(time) : null;
 
   const handleRefresh = () => {
-    setDisplayedCount(ITEMS_PER_PAGE);
+    queryClient.invalidateQueries({
+      queryKey: ["missions", "recommended", { time: timeValue }],
+    });
   };
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && displayedCount < missions.length) {
-          setDisplayedCount((prev) =>
-            Math.min(prev + ITEMS_PER_PAGE, missions.length)
-          );
-        }
-      },
-      { threshold: 1.0 }
-    );
-
-    if (observerTarget.current) {
-      observer.observe(observerTarget.current);
-    }
-
-    return () => {
-      if (observerTarget.current) {
-        observer.unobserve(observerTarget.current);
-      }
-    };
-  }, [displayedCount, missions.length]);
 
   return (
     <div>
@@ -77,12 +44,15 @@ export default function TodayMissionListView() {
         </Button>
       </div>
 
-      <div className="mt-16 -mb-96 flex flex-col gap-16">
-        {missions.slice(0, displayedCount).map((mission) => (
-          <MissionCard key={mission.id} {...mission} />
-        ))}
-        <div ref={observerTarget} className="h-1" />
-      </div>
+      <Suspense
+        fallback={
+          <div className="flex h-[50vh] items-center justify-center">
+            <LoadingSpinner className="size-100" />
+          </div>
+        }
+      >
+        <TodayMissionList />
+      </Suspense>
     </div>
   );
 }

--- a/src/pages/today-mission/components/TodayMissionList.tsx
+++ b/src/pages/today-mission/components/TodayMissionList.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import MissionCard from "@/components/MissionCard";
+import { useRecommendedMissions } from "@/pages/search/hooks/useQuery/useRecommendedMissions";
+
+const ITEMS_PER_PAGE = 10;
+
+export default function TodayMissionList() {
+  const [searchParams] = useSearchParams();
+  const time = searchParams.get("time");
+  const timeValue = time ? Number(time) : null;
+
+  const { data: missions } = useRecommendedMissions({ time: timeValue });
+
+  const [displayedCount, setDisplayedCount] = useState(ITEMS_PER_PAGE);
+  const observerTarget = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && displayedCount < missions.length) {
+          setDisplayedCount((prev) =>
+            Math.min(prev + ITEMS_PER_PAGE, missions.length)
+          );
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current);
+    }
+
+    return () => {
+      if (observerTarget.current) {
+        observer.unobserve(observerTarget.current);
+      }
+    };
+  }, [displayedCount, missions.length]);
+
+  return (
+    <div className="mt-16 -mb-96 flex flex-col gap-16">
+      {missions.slice(0, displayedCount).map((mission) => (
+        <MissionCard
+          key={mission.missionId}
+          id={mission.missionId}
+          title={mission.title}
+          keywords={mission.keywords}
+          minute={mission.durationMinutes}
+          category={mission.category}
+          quizCount={mission.quizCount}
+          isLiked={mission.isScrapped}
+        />
+      ))}
+      <div ref={observerTarget} className="h-1" />
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #72 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 홈화면 자투리 시간 별 오늘의 미션 추천 API 연동
- 탭 변경시마다 가던 week 요청 수정 -> 클로저 문제로 스토어 상태 가져오기 최신화

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|화면|
|---|
|![bandicam 2026-02-06 20-06-23-451](https://github.com/user-attachments/assets/3d18eb74-7954-43a0-87b1-23346f8821b3)|


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
미션 데이터가 없어 화면에는 보이지 않습니다..
|훅 | 에러 처리 | 사용 패턴|
| -- | -- | --|
|useSuspenseQuery | `<AsyncBoundary>` 컴포넌트 | GET 요청 (데이터 조회)|
|useMutation | onError + useApiError | POST/PUT/DELETE (데이터 변경)|

useSuspenseQuery 사용 시 기존에 말씀드린 `<Suspense>` 대신 <AsyncBoundary>` 로 감싸주시면 에러처리도 함께 할 수 있습니다! 일단 기본적으로 해두었는데 화면이 있다면 저 컴포넌트 수정해주시면 돼요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시간 선택에 따른 미션 필터링 기능 추가
  * 쿼리 기반 데이터 로딩 방식 도입으로 성능 개선

* **개선 사항**
  * 미션 리스트의 무한 스크롤 기능 강화
  * 페이지 로딩 상태 및 에러 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->