### PR TITLE
Fix: 비밀번호 재설정 에러 문구 표시

### DIFF
--- a/src/pages/settings/PasswordChangePage.tsx
+++ b/src/pages/settings/PasswordChangePage.tsx
@@ -42,9 +42,12 @@ export default function PasswordChangePage() {
   }, [newPassword, newPasswordCheck, trigger]);
 
   useEffect(() => {
+    if (!currentPassword) {
+      return;
+    }
     clearErrors("currentPassword");
     setServerCurrentPwError("");
-  }, [currentPassword, clearErrors, serverCurrentPwError]);
+  }, [currentPassword, clearErrors]);
 
   useEffect(() => {
     if (newPassword !== newPasswordCheck) {


### PR DESCRIPTION
## 🚀 관련 이슈

- close #108 

## 🔑 작업 내용

에러메세지가 표시가 안되는 문제를 해결했습니다..

## 📷 스크린샷

<img width="807" height="714" alt="스크린샷 2026-02-07 171442" src="https://github.com/user-attachments/assets/7ecf811f-aac5-4a66-8bf6-b2dde04aad9f" />
<img width="815" height="720" alt="스크린샷 2026-02-07 171405" src="https://github.com/user-attachments/assets/4d0ab4a9-eef7-4c69-805f-00e0d38fca2a" />

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 비밀번호 변경 폼의 오류 처리 논리를 개선하여 더 안정적인 상태 관리를 구현했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->