### PR TITLE
Feat: 관심사 변경 API 연동

### DIFF
--- a/src/apis/interests/settingInterests.ts
+++ b/src/apis/interests/settingInterests.ts
@@ -1,0 +1,47 @@
+import { authAPI } from "@/apis/axios";
+import type { ApiError, ApiResponse } from "@/types/api/api";
+import type { Interest, InterestDetail } from "@/types/interest/interest";
+import type { InterestWithDetails } from "@/types/interest/interest.setting";
+
+function toApiError(code: string, message: string): ApiError {
+  const e = new Error(message) as ApiError;
+  e.serverCode = code;
+  e.serverMessage = message;
+  return e;
+}
+
+export const getSettingInterests = async () => {
+  const { data } = await authAPI.get<ApiResponse<Interest[]>>("/interests");
+
+  if (!data.isSuccess) {
+    throw toApiError(data.code, data.message);
+  }
+
+  return data.result;
+};
+
+export const getSettingInterestDetails = async (interestId: number) => {
+  const { data } = await authAPI.get<ApiResponse<InterestDetail[]>>(
+    `/interests/${interestId}/details`
+  );
+
+  if (!data.isSuccess) {
+    throw toApiError(data.code, data.message);
+  }
+
+  return data.result;
+};
+
+export const getSettingInterestsWithDetails = async (): Promise<
+  InterestWithDetails[]
+> => {
+  const interests = await getSettingInterests();
+  const detailsList = await Promise.all(
+    interests.map((interest) => getSettingInterestDetails(interest.id))
+  );
+
+  return interests.map((interest, index) => ({
+    ...interest,
+    details: detailsList[index] ?? [],
+  }));
+};

--- a/src/apis/onboarding/settingOnboarding.ts
+++ b/src/apis/onboarding/settingOnboarding.ts
@@ -1,0 +1,44 @@
+import { authAPI } from "@/apis/axios";
+import type { ApiError, ApiResponse } from "@/types/api/api";
+import type {
+  SettingOnboardingRequest,
+  SettingOnboardingResponse,
+} from "@/types/onboarding/onboarding.setting";
+
+const ONBOARDING_ENDPOINT = "/members/me/onboarding";
+
+function toApiError(code: string, message: string): ApiError {
+  const e = new Error(message) as ApiError;
+  e.serverCode = code;
+  e.serverMessage = message;
+  return e;
+}
+
+export const getSettingOnboarding = async () => {
+  const { data } = await authAPI.get<ApiResponse<SettingOnboardingResponse>>(
+    ONBOARDING_ENDPOINT,
+    { params: { scope: "INTERESTS" } }
+  );
+
+  if (!data.isSuccess) {
+    throw toApiError(data.code, data.message);
+  }
+
+  return data.result;
+};
+
+export const updateSettingOnboarding = async (
+  payload: SettingOnboardingRequest
+) => {
+  const { data } = await authAPI.patch<ApiResponse<SettingOnboardingResponse>>(
+    ONBOARDING_ENDPOINT,
+    payload,
+    { params: { scope: "INTERESTS" } }
+  );
+
+  if (!data.isSuccess) {
+    throw toApiError(data.code, data.message);
+  }
+
+  return data.result;
+};

--- a/src/pages/settings/components/Interests.tsx
+++ b/src/pages/settings/components/Interests.tsx
@@ -1,30 +1,61 @@
-﻿import { useState } from "react";
+﻿import { useEffect, useRef, useState } from "react";
 import Header from "@/components/common/header/Header";
-import type {
-  InterestCategoryKey,
-  InterestSubKey,
-} from "../constants/interests";
-import {
-  EMPTY_SELECTED_INTERESTS,
-  INTEREST_CATEGORIES,
-  toggleSubSelection,
-} from "../constants/interests";
 import BottomActionBar from "./common/BottomActionBar";
 import InterestCategoryCard from "./interests/InterestCategoryCard";
+import { useSettingInterests } from "./interests/hooks/useSettingInterests";
+import { useSettingOnboarding, useUpdateSettingOnboarding } from "./interests/hooks/useSettingOnboarding";
+
+type SelectedMap = Record<number, number[]>;
 
 export default function InterestPage() {
-  const [expanded, setExpanded] = useState<InterestCategoryKey | null>(null);
-  const [selected, setSelected] = useState(EMPTY_SELECTED_INTERESTS);
+  const { data: interests } = useSettingInterests();
+  const { data: selectedFromServer } = useSettingOnboarding();
+  const { mutate, isPending } = useUpdateSettingOnboarding();
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [selected, setSelected] = useState<SelectedMap>({});
+  const didInitRef = useRef(false);
 
-  const toggle = (key: InterestCategoryKey) => {
-    setExpanded((prev) => (prev === key ? null : key));
+  useEffect(() => {
+    if (didInitRef.current) {
+      return;
+    }
+    const next: SelectedMap = {};
+    interests.forEach((interest) => {
+      next[interest.id] = [];
+    });
+    Object.entries(selectedFromServer).forEach(([interestId, subInterestIds]) => {
+      next[Number(interestId)] = subInterestIds;
+    });
+    setSelected(next);
+    didInitRef.current = true;
+  }, [interests, selectedFromServer]);
+
+  const toggle = (interestId: number) => {
+    setExpanded((prev) => (prev === interestId ? null : interestId));
   };
 
-  const handleToggleSub = (
-    categoryKey: InterestCategoryKey,
-    subKey: InterestSubKey
-  ) => {
-    setSelected((prev) => toggleSubSelection(prev, categoryKey, subKey));
+  const handleToggleSub = (interestId: number, subInterestId: number) => {
+    setSelected((prev) => {
+      const current = prev[interestId] ?? [];
+      const exists = current.includes(subInterestId);
+      return {
+        ...prev,
+        [interestId]: exists
+          ? current.filter((id) => id !== subInterestId)
+          : [...current, subInterestId],
+      };
+    });
+  };
+
+  const handleSave = () => {
+    const selections = Object.entries(selected)
+      .filter(([, subInterestIds]) => subInterestIds.length > 0)
+      .map(([interestId, subInterestIds]) => ({
+        interestId: Number(interestId),
+        subInterestIds,
+      }));
+
+    mutate({ selections });
   };
 
   return (
@@ -40,23 +71,22 @@ export default function InterestPage() {
       </div>
 
       <div className="mt-26 flex w-full flex-1 flex-col items-start gap-30">
-        {INTEREST_CATEGORIES.map((cat) => (
+        {interests.map((cat) => (
           <InterestCategoryCard
-            key={cat.key}
+            key={cat.id}
             category={cat}
-            isOpen={expanded === cat.key}
+            isOpen={expanded === cat.id}
             selected={selected}
-            onToggle={() => toggle(cat.key)}
+            onToggle={() => toggle(cat.id)}
             onToggleSub={handleToggleSub}
           />
         ))}
       </div>
 
       <BottomActionBar
-        label="설정 저장하기"
-        onClick={() => {
-          // TODO: 관심사 저장 API 호출 로직 구현
-        }}
+        label={isPending ? "저장 중..." : "설정 저장하기"}
+        onClick={handleSave}
+        disabled={isPending}
       />
     </div>
   );

--- a/src/pages/settings/components/Interests.tsx
+++ b/src/pages/settings/components/Interests.tsx
@@ -2,6 +2,7 @@
 import Header from "@/components/common/header/Header";
 import BottomActionBar from "./common/BottomActionBar";
 import InterestCategoryCard from "./interests/InterestCategoryCard";
+import InterestsSuccessModal from "./InterestsSuccessModal";
 import { useSettingInterests } from "./interests/hooks/useSettingInterests";
 import { useSettingOnboarding, useUpdateSettingOnboarding } from "./interests/hooks/useSettingOnboarding";
 
@@ -14,6 +15,7 @@ export default function InterestPage() {
   const [expanded, setExpanded] = useState<number | null>(null);
   const [selected, setSelected] = useState<SelectedMap>({});
   const didInitRef = useRef(false);
+  const [isSuccessOpen, setIsSuccessOpen] = useState(false);
 
   useEffect(() => {
     if (didInitRef.current) {
@@ -55,7 +57,14 @@ export default function InterestPage() {
         subInterestIds,
       }));
 
-    mutate({ selections });
+    mutate(
+      { selections },
+      {
+        onSuccess: () => {
+          setIsSuccessOpen(true);
+        },
+      }
+    );
   };
 
   return (
@@ -87,6 +96,11 @@ export default function InterestPage() {
         label={isPending ? "저장 중..." : "설정 저장하기"}
         onClick={handleSave}
         disabled={isPending}
+      />
+
+      <InterestsSuccessModal
+        open={isSuccessOpen}
+        onConfirm={() => setIsSuccessOpen(false)}
       />
     </div>
   );

--- a/src/pages/settings/components/InterestsSuccessModal.tsx
+++ b/src/pages/settings/components/InterestsSuccessModal.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/components/common/button/Button";
+
+type Props = {
+  open: boolean;
+  onConfirm: () => void;
+};
+
+export default function InterestsSuccessModal({ open, onConfirm }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-[rgba(36,44,61,0.40)]" />
+
+      <div
+        className="relative w-full px-35"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="interests-success-title"
+        aria-describedby="interests-success-desc"
+      >
+        <div className="flex w-full flex-col items-center gap-20 rounded-xl bg-white px-20 pt-28 pb-20">
+          <p
+            id="interests-success-title"
+            className="heading-3 text-center text-moamoa-400"
+          >
+            관심사 변경 완료 !
+          </p>
+
+          <p
+            id="interests-success-desc"
+            className="body-2 whitespace-pre-line text-center text-gray-600"
+          >
+            목표 미션 개수가 저장 되었습니다.
+            {"\n"}새로운 기준은 다음 주부터 적용됩니다.
+          </p>
+
+          <div className="flex w-full items-center justify-center">
+            <Button
+              type="button"
+              onClick={onConfirm}
+              className="flex h-48 w-154 items-center justify-center rounded-lg bg-moamoa-300"
+            >
+              <span className="heading-5 whitespace-nowrap text-white">
+                확인
+              </span>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/settings/components/InterestsSuccessModal.tsx
+++ b/src/pages/settings/components/InterestsSuccessModal.tsx
@@ -31,8 +31,8 @@ export default function InterestsSuccessModal({ open, onConfirm }: Props) {
             id="interests-success-desc"
             className="body-2 whitespace-pre-line text-center text-gray-600"
           >
-            목표 미션 개수가 저장 되었습니다.
-            {"\n"}새로운 기준은 다음 주부터 적용됩니다.
+            이제 새로운 관심사를
+            {"\n"}기준으로 콘텐츠가 추천돼요.
           </p>
 
           <div className="flex w-full items-center justify-center">

--- a/src/pages/settings/components/interests/InterestCategoryCard.tsx
+++ b/src/pages/settings/components/interests/InterestCategoryCard.tsx
@@ -1,17 +1,8 @@
-import IcDash from "@/assets/icons/ic.dottedline.svg?react";
+﻿import IcDash from "@/assets/icons/ic.dottedline.svg?react";
 import IcLeft from "@/assets/icons/ic_left.svg?react";
-import type {
-  InterestCategoryKey,
-  InterestSubKey,
-} from "../../constants/interests";
-import {
-  type EMPTY_SELECTED_INTERESTS,
-  getSelectedCount,
-  type INTEREST_CATEGORIES,
-  isSubSelected,
-} from "../../constants/interests";
+import type { InterestWithDetails } from "@/types/interest/interest.setting";
 
-type InterestCategory = (typeof INTEREST_CATEGORIES)[number];
+type SelectedMap = Record<number, number[]>;
 
 type InterestSubButtonProps = {
   label: string;
@@ -20,14 +11,11 @@ type InterestSubButtonProps = {
 };
 
 type InterestCategoryCardProps = {
-  category: InterestCategory;
+  category: InterestWithDetails;
   isOpen: boolean;
-  selected: typeof EMPTY_SELECTED_INTERESTS;
+  selected: SelectedMap;
   onToggle: () => void;
-  onToggleSub: (
-    categoryKey: InterestCategoryKey,
-    subKey: InterestSubKey
-  ) => void;
+  onToggleSub: (interestId: number, subInterestId: number) => void;
 };
 
 function InterestSubButton({
@@ -40,7 +28,7 @@ function InterestSubButton({
       type="button"
       onClick={onClick}
       className={[
-        "body-4 flex h-34 flex-1 items-center justify-center gap-4 whitespace-nowrap rounded-lg px-16 py-8",
+        "body-4 flex h-34 shrink-0 items-center justify-center gap-4 whitespace-nowrap rounded-lg px-16 py-8",
         selected ? "bg-moamoa-300 text-white" : "bg-moamoa-50 text-moamoa-300",
       ].join(" ")}
     >
@@ -56,10 +44,11 @@ export default function InterestCategoryCard({
   onToggle,
   onToggleSub,
 }: InterestCategoryCardProps) {
-  const rows = [category.subs.slice(0, 3), category.subs.slice(3)].filter(
+  const rows = [category.details.slice(0, 3), category.details.slice(3)].filter(
     (row) => row.length > 0
   );
-  const isActive = getSelectedCount(selected, category.key) > 0;
+  const selectedCount = selected[category.id]?.length ?? 0;
+  const isActive = selectedCount > 0;
 
   return (
     <div
@@ -73,14 +62,12 @@ export default function InterestCategoryCard({
         onClick={onToggle}
         className="flex w-full items-center justify-between px-26 py-13"
         aria-expanded={isOpen}
-        aria-label={`${category.label} ${isOpen ? "접기" : "펼치기"}`}
+        aria-label={`${category.name} ${isOpen ? "닫기" : "열기"}`}
       >
         <div className="flex items-center gap-12">
-          <span className="heading-4 text-black">{category.label}</span>
+          <span className="heading-4 text-black">{category.name}</span>
 
-          <span className="body-2 text-gray-900">
-            {getSelectedCount(selected, category.key)}개 선택중
-          </span>
+          <span className="body-2 text-gray-900">{selectedCount}개 선택</span>
         </div>
 
         <IcLeft
@@ -101,17 +88,21 @@ export default function InterestCategoryCard({
             <div className="mt-21 flex w-full flex-col gap-15">
               {rows.map((row, index) => (
                 <div
-                  key={row[0]?.key ?? index}
-                  className="flex w-full items-center gap-16"
+                  key={row[0]?.id ?? index}
+                  className="-mx-27 overflow-x-auto"
                 >
-                  {row.map((sub) => (
-                    <InterestSubButton
-                      key={sub.key}
-                      label={sub.label}
-                      selected={isSubSelected(selected, category.key, sub.key)}
-                      onClick={() => onToggleSub(category.key, sub.key)}
-                    />
-                  ))}
+                  <div className="flex w-max gap-16 px-27">
+                    {row.map((sub) => (
+                      <InterestSubButton
+                        key={sub.id}
+                        label={sub.name}
+                        selected={
+                          selected[category.id]?.includes(sub.id) ?? false
+                        }
+                        onClick={() => onToggleSub(category.id, sub.id)}
+                      />
+                    ))}
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/pages/settings/components/interests/hooks/useSettingInterests.ts
+++ b/src/pages/settings/components/interests/hooks/useSettingInterests.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getSettingInterestsWithDetails } from "@/apis/interests/settingInterests";
+
+export const useSettingInterests = () => {
+  return useSuspenseQuery({
+    queryKey: ["settings", "interests", "with-details"],
+    queryFn: getSettingInterestsWithDetails,
+  });
+};

--- a/src/pages/settings/components/interests/hooks/useSettingOnboarding.ts
+++ b/src/pages/settings/components/interests/hooks/useSettingOnboarding.ts
@@ -1,0 +1,43 @@
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import {
+  getSettingOnboarding,
+  updateSettingOnboarding,
+} from "@/apis/onboarding/settingOnboarding";
+import { useApiError } from "@/hooks/api/useApiError";
+import type { SettingOnboardingRequest } from "@/types/onboarding/onboarding.setting";
+
+type SelectedMap = Record<number, number[]>;
+
+export const useSettingOnboarding = () => {
+  return useSuspenseQuery({
+    queryKey: ["settings", "onboarding", "interests"],
+    queryFn: getSettingOnboarding,
+    select: (data) => {
+      const selected: SelectedMap = {};
+      data.selections.forEach((selection) => {
+        selected[selection.interestId] = selection.subInterestIds;
+      });
+      return selected;
+    },
+  });
+};
+
+export const useUpdateSettingOnboarding = () => {
+  const { handleError } = useApiError();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: SettingOnboardingRequest) =>
+      updateSettingOnboarding(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["settings", "onboarding", "interests"],
+      });
+    },
+    onError: (error) => handleError(error),
+  });
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createBrowserRouter, type RouteObject } from "react-router-dom";
 import LoginPage from "@/pages/auth/login/Login";
 import ResetPassword from "@/pages/auth/password/Password";
@@ -12,6 +13,7 @@ import Search from "@/pages/search/Search";
 import AccountInfoPage from "@/pages/settings/AccountInfoPage";
 import FaqPage from "@/pages/settings/components/FaqPage";
 import Interests from "@/pages/settings/components/Interests";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
 import InquiryDetailPage from "@/pages/settings/components/inquiry/InquiryDetailPage";
 import InquiryConsentPage from "@/pages/settings/components/inquiry/InquiryConsentPage";
 import InquiryPage from "@/pages/settings/components/inquiry/InquiryPage";
@@ -94,7 +96,17 @@ const routes: (RouteObject & { handle?: RouteHandle })[] = [
       },
       {
         path: "/settings/interests",
-        element: <Interests />,
+        element: (
+          <Suspense
+            fallback={
+              <div className="flex h-[50vh] items-center justify-center">
+                <LoadingSpinner className="size-100" />
+              </div>
+            }
+          >
+            <Interests />
+          </Suspense>
+        ),
         handle: { hideBottomNav: true },
       },
       {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import { createBrowserRouter, type RouteObject } from "react-router-dom";
 import LoginPage from "@/pages/auth/login/Login";
 import ResetPassword from "@/pages/auth/password/Password";
@@ -13,7 +12,6 @@ import Search from "@/pages/search/Search";
 import AccountInfoPage from "@/pages/settings/AccountInfoPage";
 import FaqPage from "@/pages/settings/components/FaqPage";
 import Interests from "@/pages/settings/components/Interests";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import InquiryDetailPage from "@/pages/settings/components/inquiry/InquiryDetailPage";
 import InquiryConsentPage from "@/pages/settings/components/inquiry/InquiryConsentPage";
 import InquiryPage from "@/pages/settings/components/inquiry/InquiryPage";
@@ -96,17 +94,7 @@ const routes: (RouteObject & { handle?: RouteHandle })[] = [
       },
       {
         path: "/settings/interests",
-        element: (
-          <Suspense
-            fallback={
-              <div className="flex h-[50vh] items-center justify-center">
-                <LoadingSpinner className="size-100" />
-              </div>
-            }
-          >
-            <Interests />
-          </Suspense>
-        ),
+        element: <Interests />,
         handle: { hideBottomNav: true },
       },
       {

--- a/src/types/interest/interest.setting.ts
+++ b/src/types/interest/interest.setting.ts
@@ -1,0 +1,5 @@
+import type { Interest, InterestDetail } from "./interest";
+
+export type InterestWithDetails = Interest & {
+  details: InterestDetail[];
+};

--- a/src/types/onboarding/onboarding.setting.ts
+++ b/src/types/onboarding/onboarding.setting.ts
@@ -1,0 +1,11 @@
+import type { OnboardingSelection } from "@/types/onboarding/onboarding";
+
+export type SettingOnboardingScope = "INTERESTS";
+
+export type SettingOnboardingResponse = {
+  selections: OnboardingSelection[];
+};
+
+export type SettingOnboardingRequest = {
+  selections: OnboardingSelection[];
+};


### PR DESCRIPTION
## 🚀 관련 이슈

- close #106 

## 🔑 작업 내용

관심사 수정 페이지 API 연동했습니다! 

## 📷 스크린샷

<img width="378" height="820" alt="image" src="https://github.com/user-attachments/assets/4a0c17b5-6498-435b-9df7-29328d96770f" />


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

지금 가로스크롤 두줄로 해놨는데 한줄이 더 괜찮을까요??
로딩 스피너 그냥 라우터에서 제외했습니다! 

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관심사 목록과 세부 항목이 서버에서 동적으로 로드됩니다.
  * 사용자 선택을 서버에 저장하는 기능이 추가되었습니다(저장 중 로딩 상태 표시).
  * 저장 성공 시 확인 모달이 표시됩니다.
  * 온보딩 설정을 읽고 업데이트하는 기능이 추가되어 UI와 동기화됩니다.

* **Refactor**
  * 관심사 선택 컴포넌트가 서버 데이터 기반으로 재구성되어 유지보수성과 확장성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->