### PR TITLE
Feat: 미션카드 스크랩 기능 추가

### DIFF
--- a/src/apis/missions/missions.ts
+++ b/src/apis/missions/missions.ts
@@ -1,0 +1,22 @@
+import { authAPI } from "@/apis/axios";
+import type { ApiResponse } from "@/types/api/api";
+import type {
+  MissionStatus,
+  MissionStatusResult,
+} from "@/types/mission/mission";
+
+export const updateMissionStatus = async (
+  missionId: number,
+  status: MissionStatus,
+) => {
+  const { data } = await authAPI.patch<ApiResponse<MissionStatusResult>>(
+    `/missions/${missionId}/status`,
+    { status },
+  );
+
+  if (!data.isSuccess) {
+    throw new Error(data.message);
+  }
+
+  return data.result;
+};

--- a/src/components/MissionCard.tsx
+++ b/src/components/MissionCard.tsx
@@ -9,19 +9,18 @@ interface MissionCardProps {
   minute: number;
   category: string;
   quizCount: number;
-  isLiked: boolean;
+  isScrapped: boolean;
   onHeartClick?: () => void;
   onStartClick?: () => void;
 }
 
 export default function MissionCard({
-  id: _id,
   title,
   keywords,
   minute,
   category,
   quizCount,
-  isLiked,
+  isScrapped,
   onHeartClick,
   onStartClick,
 }: MissionCardProps) {
@@ -32,8 +31,8 @@ export default function MissionCard({
         <button type="button" onClick={onHeartClick} className="shrink-0">
           <IcHeart
             className={cn(
-              "size-24 shrink-0 cursor-pointer text-moamoa-100",
-              isLiked && "fill-moamoa-100"
+              "size-24 shrink-0 cursor-pointer text-moamoa-200",
+              isScrapped && "fill-moamoa-100",
             )}
           />
         </button>

--- a/src/hooks/useScrapMission.ts
+++ b/src/hooks/useScrapMission.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateMissionStatus } from "@/apis/missions/missions";
+import { useApiError } from "@/hooks/api/useApiError";
+
+export const useScrapMission = () => {
+  const queryClient = useQueryClient();
+  const { handleError } = useApiError();
+
+  return useMutation({
+    mutationFn: ({
+      missionId,
+      isScrapped,
+    }: {
+      missionId: number;
+      isScrapped: boolean;
+    }) => updateMissionStatus(missionId, isScrapped ? "NONE" : "SCRAP"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["missions"] });
+    },
+    onError: handleError,
+  });
+};

--- a/src/hooks/useScrapMission.ts
+++ b/src/hooks/useScrapMission.ts
@@ -1,6 +1,11 @@
+import type { QueryKey } from "@tanstack/react-query";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateMissionStatus } from "@/apis/missions/missions";
 import { useApiError } from "@/hooks/api/useApiError";
+import type {
+  MissionApiResponse,
+  MissionsPageResponse,
+} from "@/types/mission/mission";
 
 export const useScrapMission = () => {
   const queryClient = useQueryClient();
@@ -14,9 +19,62 @@ export const useScrapMission = () => {
       missionId: number;
       isScrapped: boolean;
     }) => updateMissionStatus(missionId, isScrapped ? "NONE" : "SCRAP"),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["missions"] });
+
+    onMutate: async ({ missionId, isScrapped }) => {
+      await queryClient.cancelQueries({ queryKey: ["missions"] });
+
+      const previousQueries = queryClient.getQueriesData<unknown>({
+        queryKey: ["missions"],
+      });
+
+      const toggle = (m: MissionApiResponse) =>
+        m.missionId === missionId ? { ...m, isScrapped: !isScrapped } : m;
+
+      previousQueries.forEach(([queryKey, data]) => {
+        if (!data) return;
+
+        //추천 미션
+        if (Array.isArray(data)) {
+          queryClient.setQueryData(queryKey, data.map(toggle));
+          return;
+        }
+
+        //카테고리 검색 무한스크롤(마이페이지 예정)
+        const obj = data as Record<string, unknown>;
+        if ("pages" in obj) {
+          const pages = obj.pages as MissionsPageResponse[];
+          queryClient.setQueryData(queryKey, {
+            ...obj,
+            pages: pages.map((page) => ({
+              ...page,
+              missions: page.missions.map(toggle),
+            })),
+          });
+          return;
+        }
+
+        //카테고리 검색 미리보기
+        if ("missions" in obj) {
+          const page = data as MissionsPageResponse;
+          queryClient.setQueryData(queryKey, {
+            ...page,
+            missions: page.missions.map(toggle),
+          });
+        }
+      });
+
+      return { previousQueries };
     },
-    onError: handleError,
+
+    onError: (error, _variables, context) => {
+      if (context?.previousQueries) {
+        context.previousQueries.forEach(
+          ([queryKey, data]: [QueryKey, unknown]) => {
+            queryClient.setQueryData(queryKey, data);
+          }
+        );
+      }
+      handleError(error);
+    },
   });
 };

--- a/src/pages/search/components/CategoryMissionInfiniteList.tsx
+++ b/src/pages/search/components/CategoryMissionInfiniteList.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import MissionCard from "@/components/MissionCard";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import { useScrapMission } from "@/hooks/useScrapMission";
 import { useCategoryMissionsInfinite } from "../hooks/useQuery/category/useCategoryMissionsInfinite";
 
 interface CategoryMissionInfiniteListProps {
@@ -24,6 +25,8 @@ export default function CategoryMissionInfiniteList({
       seed,
     });
 
+  const scrapMutation = useScrapMission();
+
   const { ref } = useInfiniteScroll({
     fetchNextPage,
     hasNextPage,
@@ -41,7 +44,12 @@ export default function CategoryMissionInfiniteList({
           minute: m.durationMinutes,
           category: m.category,
           quizCount: m.quizCount,
-          isLiked: m.isScrapped,
+          isScrapped: m.isScrapped,
+          onHeartClick: () =>
+            scrapMutation.mutate({
+              missionId: m.missionId,
+              isScrapped: m.isScrapped,
+            }),
         })),
     [data.pages]
   );

--- a/src/pages/search/components/CategoryMissionList.tsx
+++ b/src/pages/search/components/CategoryMissionList.tsx
@@ -6,6 +6,7 @@ import {
   CATEGORY_ID_MAP,
   type MainCategory,
 } from "@/constants/missions/categories";
+import { useScrapMission } from "@/hooks/useScrapMission";
 import { useCategoryMissions } from "../hooks/useQuery/category/useCategoryMissions";
 
 interface CategoryMissionListProps {
@@ -20,6 +21,7 @@ export default function CategoryMissionList({
   const navigate = useNavigate();
   const categoryId = CATEGORY_ID_MAP[selectedCategory];
   const { data } = useCategoryMissions({ categoryId });
+  const scrapMutation = useScrapMission();
 
   const categoryMissions = data.missions.map((m) => ({
     id: m.missionId,
@@ -28,7 +30,12 @@ export default function CategoryMissionList({
     minute: m.durationMinutes,
     category: m.category,
     quizCount: m.quizCount,
-    isLiked: m.isScrapped,
+    isScrapped: m.isScrapped,
+    onHeartClick: () =>
+      scrapMutation.mutate({
+        missionId: m.missionId,
+        isScrapped: m.isScrapped,
+      }),
   }));
 
   const handleMoreClick = () => {

--- a/src/pages/search/components/SearchResultsView.tsx
+++ b/src/pages/search/components/SearchResultsView.tsx
@@ -3,6 +3,7 @@ import { LoadingSpinner } from "@/components/LoadingSpinner";
 import MissionCard from "@/components/MissionCard";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import { useScrapMission } from "@/hooks/useScrapMission";
 import { useSearchMissions } from "../hooks/useQuery/useSearchMissions";
 import RelatedKeywordsBar from "./RelatedKeywordsBar";
 
@@ -34,6 +35,7 @@ export default function SearchResultsView({
     isFetchingNextPage,
   });
 
+  const scrapMutation = useScrapMission();
   const missions = data.pages.flatMap((page) => page.missions);
 
   return (
@@ -63,7 +65,13 @@ export default function SearchResultsView({
               minute={mission.durationMinutes}
               category={mission.category}
               quizCount={mission.quizCount}
-              isLiked={mission.isScrapped}
+              isScrapped={mission.isScrapped}
+              onHeartClick={() =>
+                scrapMutation.mutate({
+                  missionId: mission.missionId,
+                  isScrapped: mission.isScrapped,
+                })
+              }
             />
           ))
         )}

--- a/src/pages/search/components/TodayMissionSection.tsx
+++ b/src/pages/search/components/TodayMissionSection.tsx
@@ -1,10 +1,12 @@
 import IcReload from "@/assets/icons/ic_reload.svg?react";
+import { useScrapMission } from "@/hooks/useScrapMission";
 import { cn } from "@/utils/cn/cn";
 import { useRecommendedMissions } from "../hooks/useQuery/useRecommendedMissions";
 import RecommendedMissionCard from "./common/RecommendedMissionCard";
 
 export default function TodayMissionSection() {
   const { data: missions, refetch } = useRecommendedMissions({ time: null });
+  const scrapMutation = useScrapMission();
   return (
     <div className="mt-48">
       <div className="flex items-center justify-between px-1">
@@ -38,6 +40,12 @@ export default function TodayMissionSection() {
                   category={mission.category}
                   description={mission.description}
                   isScrapped={mission.isScrapped}
+                  onHeartClick={() =>
+                    scrapMutation.mutate({
+                      missionId: mission.missionId,
+                      isScrapped: mission.isScrapped,
+                    })
+                  }
                 />
               </div>
             ))}

--- a/src/pages/search/components/common/RecommendedMissionCard.tsx
+++ b/src/pages/search/components/common/RecommendedMissionCard.tsx
@@ -25,7 +25,7 @@ export default function RecommendedMissionCard({
       <div className="flex items-center justify-between gap-8">
         <h3 className="body-2 truncate text-black">{title}</h3>
         <IcHeart
-          className={cn("size-24 shrink-0 cursor-pointer text-moamoa-100", isScrapped && "fill-moamoa-100")}
+          className={cn("size-24 shrink-0 cursor-pointer text-moamoa-200", isScrapped && "fill-moamoa-100")}
           onClick={onHeartClick}
         />
       </div>

--- a/src/pages/search/components/common/RecommendedMissionCard.tsx
+++ b/src/pages/search/components/common/RecommendedMissionCard.tsx
@@ -24,10 +24,14 @@ export default function RecommendedMissionCard({
     <div className="w-180 rounded-xl border border-moamoa-200 bg-white px-16 py-18">
       <div className="flex items-center justify-between gap-8">
         <h3 className="body-2 truncate text-black">{title}</h3>
-        <IcHeart
-          className={cn("size-24 shrink-0 cursor-pointer text-moamoa-200", isScrapped && "fill-moamoa-100")}
-          onClick={onHeartClick}
-        />
+        <button type="button" onClick={onHeartClick} className="shrink-0">
+          <IcHeart
+            className={cn(
+              "size-24 shrink-0 cursor-pointer text-moamoa-200",
+              isScrapped && "fill-moamoa-100"
+            )}
+          />
+        </button>
       </div>
 
       <div className="-mx-16 mt-18 overflow-x-auto">
@@ -53,7 +57,9 @@ export default function RecommendedMissionCard({
           <span>카테고리 :</span>
           <span className="ml-3">{category}</span>
         </div>
-        {description && <p className="body-5 truncate text-black">{description}</p>}
+        {description && (
+          <p className="body-5 truncate text-black">{description}</p>
+        )}
       </div>
     </div>
   );

--- a/src/pages/today-mission/components/TodayMissionList.tsx
+++ b/src/pages/today-mission/components/TodayMissionList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import MissionCard from "@/components/MissionCard";
+import { useScrapMission } from "@/hooks/useScrapMission";
 import { useRecommendedMissions } from "@/pages/search/hooks/useQuery/useRecommendedMissions";
 
 const ITEMS_PER_PAGE = 10;
@@ -11,6 +12,7 @@ export default function TodayMissionList() {
   const timeValue = time ? Number(time) : null;
 
   const { data: missions } = useRecommendedMissions({ time: timeValue });
+  const scrapMutation = useScrapMission();
 
   const [displayedCount, setDisplayedCount] = useState(ITEMS_PER_PAGE);
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -49,7 +51,13 @@ export default function TodayMissionList() {
           minute={mission.durationMinutes}
           category={mission.category}
           quizCount={mission.quizCount}
-          isLiked={mission.isScrapped}
+          isScrapped={mission.isScrapped}
+          onHeartClick={() =>
+            scrapMutation.mutate({
+              missionId: mission.missionId,
+              isScrapped: mission.isScrapped,
+            })
+          }
         />
       ))}
       <div ref={observerTarget} className="h-1" />

--- a/src/types/mission/mission.ts
+++ b/src/types/mission/mission.ts
@@ -15,6 +15,14 @@ export interface MissionsPageResponse {
   hasNext: boolean;
 }
 
+export type MissionStatus = "NONE" | "SCRAP" | "FAIL";
+
+export interface MissionStatusResult {
+  missionId: number;
+  status: string;
+  attemptCount: number;
+}
+
 export interface Category {
   categoryId: number;
   name: string;


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #104 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- MissionCard 스크랩 기능 추가
- RecommendedMissionCard 스크랩 기능 추가
- 하트 스타일 수정
## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|화면|
|---|
|![bandicam 2026-02-08 01-02-56-266](https://github.com/user-attachments/assets/b42326d0-ba9f-418f-8517-4bb1c7ba3738)|

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
- 미션 카드 두 종류 중에 사용하시는 분 있으면 참고해주세요!(아마 마이페이지)
- missions/{missionId}/status API 작성해두었습니다!
- SCRAP 부분만 구현해두었으니 훅은 별개로 만드시고 API 코드 재사용 부탁드립니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 미션 스크랩 기능 추가: 하트 아이콘을 통해 미션을 스크랩하거나 스크랩 해제할 수 있습니다.
  * 검색 결과, 카테고리, 오늘의 미션 등 여러 페이지에서 스크랩 기능을 이용할 수 있습니다.
  * 즉각적인 UI 업데이트로 부드러운 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->