### PR TITLE
Feat: 검색 결과 없을 때의 UI 구현 

### DIFF
--- a/src/pages/search/components/NoSearchResults.tsx
+++ b/src/pages/search/components/NoSearchResults.tsx
@@ -1,0 +1,26 @@
+import IcSearch from "@/assets/icons/ic_search.svg?react";
+
+interface NoSearchResultsProps {
+  searchText: string;
+}
+
+const NoSearchResults = ({ searchText }: NoSearchResultsProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center px-layout-side pt-100">
+      <IcSearch className="text-gray-400" width={87} height={87} />
+      <h2 className="heading6 mt-20 text-gray-800">결과 없음</h2>
+      <p className="body5 mt-12 whitespace-nowrap text-center text-gray-600">
+        {searchText} 와(과) 일치하는 검색어에
+        <br />
+        대한 검색 결과가 없습니다
+      </p>
+      <p className="body5 mt-8 whitespace-nowrap text-center text-gray-600">
+        다른 검색어 또는 보다 적은 검색어를 사용하여
+        <br />
+        다시 검색해 보세요
+      </p>
+    </div>
+  );
+};
+
+export default NoSearchResults;

--- a/src/pages/search/components/SearchResultsView.tsx
+++ b/src/pages/search/components/SearchResultsView.tsx
@@ -5,6 +5,7 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useScrapMission } from "@/hooks/useScrapMission";
 import { useSearchMissions } from "../hooks/useQuery/useSearchMissions";
+import NoSearchResults from "./NoSearchResults";
 import RelatedKeywordsBar from "./RelatedKeywordsBar";
 
 interface SearchResultsViewProps {
@@ -52,9 +53,7 @@ export default function SearchResultsView({
 
       <div className="mt-12 flex flex-col gap-16 pb-38">
         {missions.length === 0 ? (
-          <div className="mt-50 flex justify-center">
-            <span className="body-2 text-gray-400">검색 결과가 없습니다</span>
-          </div>
+          <NoSearchResults searchText={debouncedSearchText} />
         ) : (
           missions.map((mission) => (
             <MissionCard

--- a/src/pages/search/components/TodayMissionSection.tsx
+++ b/src/pages/search/components/TodayMissionSection.tsx
@@ -38,7 +38,7 @@ export default function TodayMissionSection() {
                   keywords={mission.keywords}
                   durationMinutes={mission.durationMinutes}
                   category={mission.category}
-                  description={mission.description}
+                  quizCount={mission.quizCount}
                   isScrapped={mission.isScrapped}
                   onHeartClick={() =>
                     scrapMutation.mutate({

--- a/src/pages/search/components/common/RecommendedMissionCard.tsx
+++ b/src/pages/search/components/common/RecommendedMissionCard.tsx
@@ -6,7 +6,7 @@ interface RecommendedMissionCardProps {
   keywords: string[];
   durationMinutes: number;
   category: string;
-  quizCount?: number;
+  quizCount: number;
   isScrapped?: boolean;
   onHeartClick?: () => void;
 }

--- a/src/pages/search/components/common/RecommendedMissionCard.tsx
+++ b/src/pages/search/components/common/RecommendedMissionCard.tsx
@@ -6,7 +6,7 @@ interface RecommendedMissionCardProps {
   keywords: string[];
   durationMinutes: number;
   category: string;
-  description?: string;
+  quizCount?: number;
   isScrapped?: boolean;
   onHeartClick?: () => void;
 }
@@ -16,12 +16,12 @@ export default function RecommendedMissionCard({
   keywords,
   durationMinutes,
   category,
-  description,
+  quizCount,
   isScrapped,
   onHeartClick,
 }: RecommendedMissionCardProps) {
   return (
-    <div className="w-180 rounded-xl border border-moamoa-200 bg-white px-16 py-18">
+    <div className="w-176 rounded-xl border border-moamoa-200 bg-white px-16 py-27">
       <div className="flex items-center justify-between gap-8">
         <h3 className="body-2 truncate text-black">{title}</h3>
         <button type="button" onClick={onHeartClick} className="shrink-0">
@@ -48,18 +48,20 @@ export default function RecommendedMissionCard({
         </div>
       </div>
 
-      <div className="mt-8 flex flex-col gap-4">
-        <div className="body-2 flex items-center text-black">
+      <div className="mt-8 flex flex-col">
+        <div className="body-4 mb-8 flex items-center text-black">
           <span>예상 소요 시간 :</span>
           <span className="ml-3">{durationMinutes}분</span>
         </div>
-        <div className="body-5 flex items-center text-black">
+        <div className="body-5 mb-4 flex items-center text-black">
           <span>카테고리 :</span>
           <span className="ml-3">{category}</span>
         </div>
-        {description && (
-          <p className="body-5 truncate text-black">{description}</p>
-        )}
+
+        <div className="body-5 flex items-center text-black">
+          <span>퀴즈 개수 :</span>
+          <span className="ml-3">{quizCount}개</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #73 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 검색 결과 없을 때의 UI 구현 
- 오늘의 미션 추천 카드 필드명 수정

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|사진|
|---|
|<img width="250" alt="image" src="https://github.com/user-attachments/assets/bd7aed43-3bd3-4953-8917-2dcbc62071c2" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 검색 결과가 없을 때 사용자 친화적인 안내 화면을 추가했습니다.

* **스타일**
  * 미션 카드에서 설명 텍스트 대신 퀴즈 개수를 표시하도록 변경했습니다.
  * 미션 카드의 레이아웃 및 간격을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->