### PR TITLE
Feat: 일간 및 주간 목표 실패 시 팝업 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,22 +2,34 @@ import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import { storage } from "./apis/storage";
 import { useAttendanceCheck } from "./hooks/attendance/useAttendanceCheck";
+import { useGoalPopupCheck } from "./hooks/goal/useGoalPopupCheck";
+import DailyGoalFailure from "./pages/mission/goal/DailyGoalFailure";
+import WeeklyGoalFailure from "./pages/mission/goal/WeeklyGoalFailure";
 import router from "./routes/router";
 
 function App() {
   const { handleCheckAttendance } = useAttendanceCheck();
+  const {
+    currentPopup,
+    shouldNavigateToSearch,
+    handleCheckGoalPopups,
+    handleClosePopup,
+    handleMissionExplore,
+  } = useGoalPopupCheck();
 
   useEffect(() => {
     const token = storage.getToken();
     if (!token) return;
 
     handleCheckAttendance();
+    handleCheckGoalPopups();
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         const currentToken = storage.getToken();
         if (currentToken) {
           handleCheckAttendance();
+          handleCheckGoalPopups();
         }
       }
     };
@@ -27,9 +39,40 @@ function App() {
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <RouterProvider router={router} />;
+  useEffect(() => {
+    if (shouldNavigateToSearch) {
+      router.navigate("/search");
+    }
+  }, [shouldNavigateToSearch]);
+
+  return (
+    <>
+      <RouterProvider router={router} />
+
+      {currentPopup && (
+        <div className="fixed inset-0 z-50 bg-white px-layout-side">
+          {currentPopup.goalType === "DAILY" && (
+            <DailyGoalFailure
+              completedMissions={currentPopup.achievedCount}
+              totalMissions={currentPopup.targetCount}
+              onClose={handleClosePopup}
+              onMissionExplore={handleMissionExplore}
+            />
+          )}
+          {currentPopup.goalType === "WEEKLY" && (
+            <WeeklyGoalFailure
+              completedMissions={currentPopup.achievedCount}
+              totalMissions={currentPopup.targetCount}
+              onClose={handleClosePopup}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ function App() {
     handleCheckGoalPopups,
     handleClosePopup,
     handleMissionExplore,
+    resetNavigateToSearch,
   } = useGoalPopupCheck();
 
   useEffect(() => {
@@ -45,8 +46,9 @@ function App() {
   useEffect(() => {
     if (shouldNavigateToSearch) {
       router.navigate("/search");
+      resetNavigateToSearch();
     }
-  }, [shouldNavigateToSearch]);
+  }, [shouldNavigateToSearch, resetNavigateToSearch]);
 
   return (
     <>

--- a/src/apis/goal/goal.ts
+++ b/src/apis/goal/goal.ts
@@ -1,0 +1,22 @@
+import { authAPI } from "@/apis/axios";
+import type { ApiResponse } from "@/types/api/api";
+import type { GoalPopupsResponse } from "@/types/goal/goal";
+
+export const getGoalPopups = async () => {
+  const { data } = await authAPI.get<ApiResponse<GoalPopupsResponse>>(
+    "/members/me/goal-popups"
+  );
+
+  if (!data.isSuccess) throw new Error(data.message);
+  return data.result;
+};
+
+export const markGoalPopupShown = async (goalResultId: number) => {
+  const { data } = await authAPI.patch<ApiResponse<null>>(
+    `/members/me/goal-popups/${goalResultId}/shown`,
+    {}
+  );
+
+  if (!data.isSuccess) throw new Error(data.message);
+  return data.result;
+};

--- a/src/hooks/goal/useGoalPopupCheck.ts
+++ b/src/hooks/goal/useGoalPopupCheck.ts
@@ -56,11 +56,16 @@ export const useGoalPopupCheck = () => {
   const handleClosePopup = () => closePopupWithAction(false);
   const handleMissionExplore = () => closePopupWithAction(true);
 
+  const resetNavigateToSearch = () => {
+    setShouldNavigateToSearch(false);
+  };
+
   return {
     currentPopup,
     shouldNavigateToSearch,
     handleCheckGoalPopups,
     handleClosePopup,
     handleMissionExplore,
+    resetNavigateToSearch,
   };
 };

--- a/src/hooks/goal/useGoalPopupCheck.ts
+++ b/src/hooks/goal/useGoalPopupCheck.ts
@@ -36,15 +36,16 @@ export const useGoalPopupCheck = () => {
         (p) => p.goalResultId !== currentPopup.goalResultId
       );
 
+      if (navigateToSearch) {
+        setShouldNavigateToSearch(true);
+      }
+
       if (remainingPopups.length > 0) {
         setPopupQueue(remainingPopups);
         setCurrentPopup(remainingPopups[0]);
       } else {
         setPopupQueue([]);
         setCurrentPopup(null);
-        if (navigateToSearch) {
-          setShouldNavigateToSearch(true);
-        }
       }
     } catch (error) {
       console.error("Goal popup 확인 처리 실패:", error);

--- a/src/hooks/goal/useGoalPopupCheck.ts
+++ b/src/hooks/goal/useGoalPopupCheck.ts
@@ -1,0 +1,66 @@
+import { useRef, useState } from "react";
+import { getGoalPopups } from "@/apis/goal/goal";
+import type { GoalPopup } from "@/types/goal/goal";
+import { useMarkGoalPopupShown } from "./useMarkGoalPopupShown";
+
+export const useGoalPopupCheck = () => {
+  const [popupQueue, setPopupQueue] = useState<GoalPopup[]>([]);
+  const [currentPopup, setCurrentPopup] = useState<GoalPopup | null>(null);
+  const [shouldNavigateToSearch, setShouldNavigateToSearch] = useState(false);
+  const hasCheckedRef = useRef(false);
+  const markShownMutation = useMarkGoalPopupShown();
+
+  const handleCheckGoalPopups = async () => {
+    if (hasCheckedRef.current) return;
+
+    try {
+      const result = await getGoalPopups();
+      hasCheckedRef.current = true;
+
+      if (result.popups.length > 0) {
+        setPopupQueue(result.popups);
+        setCurrentPopup(result.popups[0]);
+      }
+    } catch (error) {
+      console.error("Goal popups 조회 실패:", error);
+    }
+  };
+
+  const closePopupWithAction = async (navigateToSearch = false) => {
+    if (!currentPopup) return;
+
+    try {
+      await markShownMutation.mutateAsync(currentPopup.goalResultId);
+
+      const remainingPopups = popupQueue.filter(
+        (p) => p.goalResultId !== currentPopup.goalResultId
+      );
+
+      if (remainingPopups.length > 0) {
+        setPopupQueue(remainingPopups);
+        setCurrentPopup(remainingPopups[0]);
+      } else {
+        setPopupQueue([]);
+        setCurrentPopup(null);
+        if (navigateToSearch) {
+          setShouldNavigateToSearch(true);
+        }
+      }
+    } catch (error) {
+      console.error("Goal popup 확인 처리 실패:", error);
+      setCurrentPopup(null);
+      setPopupQueue([]);
+    }
+  };
+
+  const handleClosePopup = () => closePopupWithAction(false);
+  const handleMissionExplore = () => closePopupWithAction(true);
+
+  return {
+    currentPopup,
+    shouldNavigateToSearch,
+    handleCheckGoalPopups,
+    handleClosePopup,
+    handleMissionExplore,
+  };
+};

--- a/src/hooks/goal/useMarkGoalPopupShown.ts
+++ b/src/hooks/goal/useMarkGoalPopupShown.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { markGoalPopupShown } from "@/apis/goal/goal";
+
+export const useMarkGoalPopupShown = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (goalResultId: number) => markGoalPopupShown(goalResultId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["goal", "popups"] });
+    },
+  });
+};

--- a/src/pages/mission/goal/DailyGoalFailure.tsx
+++ b/src/pages/mission/goal/DailyGoalFailure.tsx
@@ -24,7 +24,7 @@ export default function DailyGoalFailure({
         <IcBlueBook className="h-88.6 w-auto" />
       </div>
 
-      <div className="z-35 mt-235 w-full rounded-[20px] border-2 border-moamoa-100 bg-white px-23 pt-32 pb-28">
+      <div className="z-35 mt-235 w-full rounded-2xl border-2 border-moamoa-100 bg-white px-23 pt-32 pb-28">
         <div className="flex flex-col items-center gap-12">
           <p className="heading-2 text-center text-black">
             오늘 목표 중 <br />

--- a/src/pages/mission/goal/DailyGoalFailure.tsx
+++ b/src/pages/mission/goal/DailyGoalFailure.tsx
@@ -4,13 +4,15 @@ import IcFirstFailSquirrel from "@/assets/icons/mission/ic_first_fail_squirrel.s
 interface DailyGoalFailureProps {
   completedMissions: number;
   totalMissions: number;
-  onClose: () => void;
+  onClose: () => void | Promise<void>;
+  onMissionExplore?: () => void | Promise<void>;
 }
 
 export default function DailyGoalFailure({
   completedMissions,
   totalMissions,
   onClose,
+  onMissionExplore,
 }: DailyGoalFailureProps) {
   return (
     <div className="relative -mb-96 flex min-h-screen flex-col items-center">
@@ -57,7 +59,7 @@ export default function DailyGoalFailure({
           </button>
           <button
             type="button"
-            onClick={onClose}
+            onClick={onMissionExplore || onClose}
             className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-300 py-12 text-white"
           >
             미션 탐색

--- a/src/pages/mission/goal/WeeklyGoalFailure.tsx
+++ b/src/pages/mission/goal/WeeklyGoalFailure.tsx
@@ -4,7 +4,7 @@ import IcTears from "@/assets/icons/mission/ic_tears.svg?react";
 interface WeeklyGoalFailureProps {
   completedMissions: number;
   totalMissions: number;
-  onClose: () => void;
+  onClose: () => void | Promise<void>;
 }
 
 export default function WeeklyGoalFailure({
@@ -25,7 +25,7 @@ export default function WeeklyGoalFailure({
         <IcTears className="h-17 w-112" />
       </div>
 
-      <div className="z-35 mt-228 w-full rounded-[20px] border-2 border-moamoa-100 bg-white px-23 pt-32 pb-28">
+      <div className="z-35 mt-228 w-full rounded-2xl border-2 border-moamoa-100 bg-white px-23 pt-32 pb-28">
         <div className="flex flex-col items-center gap-12">
           <p className="heading-2 text-center text-black">
             이번주 목표 중 <br />

--- a/src/types/goal/goal.ts
+++ b/src/types/goal/goal.ts
@@ -1,0 +1,15 @@
+export type GoalType = "DAILY" | "WEEKLY";
+export type GoalStatus = "SUCCESS" | "FAIL";
+
+export interface GoalPopup {
+  goalResultId: number;
+  goalType: GoalType;
+  goalDate: string;
+  targetCount: number;
+  achievedCount: number;
+  status: GoalStatus;
+}
+
+export interface GoalPopupsResponse {
+  popups: GoalPopup[];
+}


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #147 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 일간 및 주간 목표 실패 시 팝업 API 연동

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|영상|
|---|
|![화면 기록 2026-02-10 오후 3 09 02](https://github.com/user-attachments/assets/4e72428f-a750-4424-a9ef-7f38cba17c8c)|


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
일간+주간 실패 값이 둘 다 넘어왔을 때 아래와 같이 구현하였습니다.
  - 확인(일간) -> 닫기(주간) -> 홈
  - 미션탐색(일간) -> 닫기(주간) -> 탐색화면

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 일일/주간 목표 실패 팝업 추가 — 목표 미달 시 오버레이로 알림 표시
  * 앱 시작 및 활성화 시 자동으로 목표 팝업 확인
  * 팝업에서 닫기 및 ‘미션 탐색’ 선택 시 검색 화면으로 이동 지원

* **수정**
  * 팝업 카드 디자인 반영(더 둥근 모서리) 및 닫기 동작의 비동기 처리 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->