### PR TITLE
Feat: 소셜 로그인 약관 동의 후 온보딩 이동 처리

### DIFF
--- a/src/pages/auth/login/hooks/useMutation/useLogin.ts
+++ b/src/pages/auth/login/hooks/useMutation/useLogin.ts
@@ -41,7 +41,10 @@ export const useLogin = (handlers?: LoginErrorHandlers) => {
       if (!result.policyAgreed) {
         navigate("/terms", {
           replace: true,
-          state: { from: location.pathname },
+          state: {
+            from: location.pathname,
+            onboardingCompleted: result.onboardingCompleted,
+          },
         });
         return;
       }

--- a/src/pages/auth/login/hooks/useMutation/useLogin.ts
+++ b/src/pages/auth/login/hooks/useMutation/useLogin.ts
@@ -48,7 +48,7 @@ export const useLogin = (handlers?: LoginErrorHandlers) => {
         });
         return;
       }
-      navigate(result.onboardingCompleted ? "/" : "/onboarding");
+      navigate(result.onboardingCompleted ? "/home" : "/onboarding");
     },
     onError: (error) => {
       const apiError = error as ApiError;

--- a/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
+++ b/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
@@ -36,7 +36,7 @@ export const useSocialLogin = (handlers?: SocialLoginErrorHandlers) => {
         return;
       }
 
-      navigate(result.onboardingCompleted ? "/" : "/onboarding", {
+      navigate(result.onboardingCompleted ? "/home" : "/onboarding", {
         replace: true,
       });
     },

--- a/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
+++ b/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
@@ -28,7 +28,10 @@ export const useSocialLogin = (handlers?: SocialLoginErrorHandlers) => {
       if (!result.policyAgreed) {
         navigate("/terms", {
           replace: true,
-          state: { from: location.pathname },
+          state: {
+            from: location.pathname,
+            onboardingCompleted: result.onboardingCompleted,
+          },
         });
         return;
       }

--- a/src/pages/auth/terms/Terms.tsx
+++ b/src/pages/auth/terms/Terms.tsx
@@ -14,10 +14,16 @@ export default function TermsPage() {
   const location = useLocation();
   const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
 
-  const { agreements: initialChecked, from } = (location.state as {
+  const { agreements: initialChecked, from, onboardingCompleted } = (location
+    .state as {
     agreements?: Record<TermKey, boolean>;
     from?: string;
-  } | null) ?? { agreements: undefined, from: undefined };
+    onboardingCompleted?: boolean;
+  } | null) ?? {
+    agreements: undefined,
+    from: undefined,
+    onboardingCompleted: undefined,
+  };
 
   const [checked, setChecked] = useState<Record<TermKey, boolean>>({
     terms: false,
@@ -42,7 +48,9 @@ export default function TermsPage() {
         navigate(from, { replace: true });
         return;
       }
-      navigate("/home", { replace: true });
+      const nextPath =
+        onboardingCompleted === false ? "/onboarding" : "/home";
+      navigate(nextPath, { replace: true });
     },
   });
 


### PR DESCRIPTION
## 🚀 관련 이슈


- close #156

## 🔑 작업 내용

소셜 로그인 약관 동의 후 온보딩 이동 처리

## 🌐 공유 사항 to 리뷰어

기존에 소셜 로그인으로 처음 올 경우에 약관 미동의 시 온보딩 분기가 적용되지 않아서 온보딩이 안 뜨는 문제가 있었는데 해결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 약관 동의 페이지의 네비게이션 상태에 온보딩 완료 여부를 포함하도록 확장했습니다.
  * 로그인(일반·소셜) 후 흐름을 개선하여, 온보딩이 완료된 경우 홈으로(/home) 이동하고, 미완료인 경우 온보딩으로(/onboarding) 안내합니다.
  * 약관 제출 시 가능한 경우 원래의 출발 페이지로 복귀하는 동작을 유지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->