### PR TITLE
Feat: 로그아웃 및 탈퇴 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
-import { storage } from "./apis/storage";
+import GlobalModals from "./components/GlobalModals";
+import GoalPopups from "./components/GoalPopups";
 import { useAttendanceCheck } from "./hooks/attendance/useAttendanceCheck";
 import { useGoalPopupCheck } from "./hooks/goal/useGoalPopupCheck";
-import DailyGoalFailure from "./pages/mission/goal/DailyGoalFailure";
-import WeeklyGoalFailure from "./pages/mission/goal/WeeklyGoalFailure";
+import { useAppInitializer } from "./hooks/useAppInitializer";
 import router from "./routes/router";
+import { useSettingsStore } from "./store/settings";
 
 function App() {
   const { handleCheckAttendance } = useAttendanceCheck();
@@ -17,31 +18,15 @@ function App() {
     handleMissionExplore,
     resetNavigateToSearch,
   } = useGoalPopupCheck();
+  const showLogoutToast = useSettingsStore((state) => state.showLogoutToast);
+  const setShowLogoutToast = useSettingsStore(
+    (state) => state.setShowLogoutToast
+  );
 
-  useEffect(() => {
-    const token = storage.getToken();
-    if (!token) return;
-
-    handleCheckAttendance();
-    handleCheckGoalPopups();
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        const currentToken = storage.getToken();
-        if (currentToken) {
-          handleCheckAttendance();
-          handleCheckGoalPopups();
-        }
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useAppInitializer({
+    onCheckAttendance: handleCheckAttendance,
+    onCheckGoalPopups: handleCheckGoalPopups,
+  });
 
   useEffect(() => {
     if (shouldNavigateToSearch) {
@@ -50,29 +35,24 @@ function App() {
     }
   }, [shouldNavigateToSearch, resetNavigateToSearch]);
 
+  useEffect(() => {
+    if (showLogoutToast) {
+      const timer = setTimeout(() => {
+        setShowLogoutToast(false);
+      }, 2500);
+      return () => clearTimeout(timer);
+    }
+  }, [showLogoutToast, setShowLogoutToast]);
+
   return (
     <>
       <RouterProvider router={router} />
-
-      {currentPopup && (
-        <div className="fixed inset-0 z-50 bg-white px-layout-side">
-          {currentPopup.goalType === "DAILY" && (
-            <DailyGoalFailure
-              completedMissions={currentPopup.achievedCount}
-              totalMissions={currentPopup.targetCount}
-              onClose={handleClosePopup}
-              onMissionExplore={handleMissionExplore}
-            />
-          )}
-          {currentPopup.goalType === "WEEKLY" && (
-            <WeeklyGoalFailure
-              completedMissions={currentPopup.achievedCount}
-              totalMissions={currentPopup.targetCount}
-              onClose={handleClosePopup}
-            />
-          )}
-        </div>
-      )}
+      <GoalPopups
+        currentPopup={currentPopup}
+        onClose={handleClosePopup}
+        onMissionExplore={handleMissionExplore}
+      />
+      <GlobalModals />
     </>
   );
 }

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -6,7 +6,7 @@ import type {
   SocialLoginResult,
   SocialLoginTokenRequest,
 } from "@/types/auth/social";
-import { publicAPI } from "../axios";
+import { authAPI, publicAPI } from "../axios";
 
 export const login = async (payload: LoginRequest) => {
   try {
@@ -90,6 +90,33 @@ export const exchangeSocialToken = async (
       "/auth/oauth2/token",
       payload
     );
+
+    if (!data.isSuccess) {
+      const apiError = new Error(data.message) as ApiError;
+      apiError.serverCode = data.code;
+      apiError.serverMessage = data.message;
+      throw apiError;
+    }
+
+    return data.result;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const data = error.response?.data as ApiResponse<null> | undefined;
+      if (data) {
+        const apiError = new Error(data.message) as ApiError;
+        apiError.serverCode = data.code;
+        apiError.serverMessage = data.message;
+        throw apiError;
+      }
+    }
+
+    throw error;
+  }
+};
+
+export const logout = async () => {
+  try {
+    const { data } = await authAPI.post<ApiResponse<null>>("/auth/logout");
 
     if (!data.isSuccess) {
       const apiError = new Error(data.message) as ApiError;

--- a/src/apis/profile/profile.ts
+++ b/src/apis/profile/profile.ts
@@ -38,3 +38,13 @@ export const updateMyProfile = async (payload: UpdateMyProfileRequest) => {
 
   return data.result;
 };
+
+export const deleteMember = async () => {
+  const { data } = await authAPI.delete<ApiResponse<null>>("/members/me");
+
+  if (!data.isSuccess) {
+    throw toApiError(data.code, data.message);
+  }
+
+  return data.result;
+};

--- a/src/apis/storage.ts
+++ b/src/apis/storage.ts
@@ -1,7 +1,17 @@
 const TOKEN_KEY = "accessToken";
+const POLICY_AGREED_KEY = "policyAgreed";
 
 export const storage = {
   getToken: () => localStorage.getItem(TOKEN_KEY),
   setToken: (token: string) => localStorage.setItem(TOKEN_KEY, token),
   removeToken: () => localStorage.removeItem(TOKEN_KEY),
+
+  getPolicyAgreed: (): boolean | null => {
+    const value = localStorage.getItem(POLICY_AGREED_KEY);
+    if (value === null) return null;
+    return value === "true";
+  },
+  setPolicyAgreed: (agreed: boolean) =>
+    localStorage.setItem(POLICY_AGREED_KEY, String(agreed)),
+  removePolicyAgreed: () => localStorage.removeItem(POLICY_AGREED_KEY),
 };

--- a/src/components/GlobalModals.tsx
+++ b/src/components/GlobalModals.tsx
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import LogoutToast from "@/pages/settings/components/LogoutToast";
+import WithdrawSuccessModal from "@/pages/settings/components/WithdrawSuccessModal";
+import router from "@/routes/router";
+import { useAuthStore } from "@/store/auth";
+import { useSettingsStore } from "@/store/settings";
+
+export default function GlobalModals() {
+  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
+  const showLogoutToast = useSettingsStore((state) => state.showLogoutToast);
+  const showWithdrawSuccessModal = useSettingsStore(
+    (state) => state.showWithdrawSuccessModal
+  );
+  const setShowWithdrawSuccessModal = useSettingsStore(
+    (state) => state.setShowWithdrawSuccessModal
+  );
+
+  const handleWithdrawClose = useCallback(() => {
+    setShowWithdrawSuccessModal(false);
+    router.navigate("/");
+    setTimeout(() => {
+      setAuthenticated(false);
+    }, 100);
+  }, [setShowWithdrawSuccessModal, setAuthenticated]);
+
+  return (
+    <>
+      <LogoutToast show={showLogoutToast} />
+      <WithdrawSuccessModal
+        open={showWithdrawSuccessModal}
+        onClose={handleWithdrawClose}
+      />
+    </>
+  );
+}

--- a/src/components/GoalPopups.tsx
+++ b/src/components/GoalPopups.tsx
@@ -1,0 +1,37 @@
+import DailyGoalFailure from "@/pages/mission/goal/DailyGoalFailure";
+import WeeklyGoalFailure from "@/pages/mission/goal/WeeklyGoalFailure";
+import type { GoalPopup } from "@/types/goal/goal";
+
+interface GoalPopupsProps {
+  currentPopup: GoalPopup | null;
+  onClose: () => void;
+  onMissionExplore: () => void;
+}
+
+export default function GoalPopups({
+  currentPopup,
+  onClose,
+  onMissionExplore,
+}: GoalPopupsProps) {
+  if (!currentPopup) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-white px-layout-side">
+      {currentPopup.goalType === "DAILY" && (
+        <DailyGoalFailure
+          completedMissions={currentPopup.achievedCount}
+          totalMissions={currentPopup.targetCount}
+          onClose={onClose}
+          onMissionExplore={onMissionExplore}
+        />
+      )}
+      {currentPopup.goalType === "WEEKLY" && (
+        <WeeklyGoalFailure
+          completedMissions={currentPopup.achievedCount}
+          totalMissions={currentPopup.targetCount}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -4,14 +4,22 @@ import { storage } from "@/apis/storage";
 import { useAuthStore } from "@/store/auth";
 
 export const useAuth = () => {
-  const { isLoading, isAuthenticated, policyAgreed, setAuthenticated, setLoading } =
-    useAuthStore();
+  const {
+    isLoading,
+    isAuthenticated,
+    policyAgreed,
+    setAuthenticated,
+    setLoading,
+    setPolicyAgreed,
+  } = useAuthStore();
 
   useEffect(() => {
     const checkAuth = async () => {
       const accessToken = storage.getToken();
       if (accessToken) {
         setAuthenticated(true);
+        const storedPolicyAgreed = storage.getPolicyAgreed();
+        setPolicyAgreed(storedPolicyAgreed ?? true);
         setLoading(false);
         return;
       }
@@ -19,6 +27,8 @@ export const useAuth = () => {
         const newToken = await refreshAccessToken();
         storage.setToken(newToken);
         setAuthenticated(true);
+        const storedPolicyAgreed = storage.getPolicyAgreed();
+        setPolicyAgreed(storedPolicyAgreed ?? true);
       } catch {
         storage.removeToken();
         setAuthenticated(false);
@@ -28,7 +38,7 @@ export const useAuth = () => {
     };
 
     checkAuth();
-  }, [setAuthenticated, setLoading]);
+  }, [setAuthenticated, setLoading, setPolicyAgreed]);
 
   return { isLoading, isAuthenticated, policyAgreed };
 };

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { storage } from "@/apis/storage";
+
+interface UseAppInitializerProps {
+  onCheckAttendance: () => void;
+  onCheckGoalPopups: () => void;
+}
+
+export const useAppInitializer = ({
+  onCheckAttendance,
+  onCheckGoalPopups,
+}: UseAppInitializerProps) => {
+  useEffect(() => {
+    const token = storage.getToken();
+    if (!token) return;
+
+    onCheckAttendance();
+    onCheckGoalPopups();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        const currentToken = storage.getToken();
+        if (currentToken) {
+          onCheckAttendance();
+          onCheckGoalPopups();
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+    
+  }, []);
+};

--- a/src/pages/auth/login/hooks/useMutation/useLogin.ts
+++ b/src/pages/auth/login/hooks/useMutation/useLogin.ts
@@ -36,6 +36,7 @@ export const useLogin = (handlers?: LoginErrorHandlers) => {
     mutationFn: (payload: LoginRequest) => login(payload),
     onSuccess: (result) => {
       storage.setToken(result.token.accessToken);
+      storage.setPolicyAgreed(result.policyAgreed);
       setAuthenticated(true);
       setPolicyAgreed(result.policyAgreed);
       if (!result.policyAgreed) {

--- a/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
+++ b/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
@@ -22,6 +22,7 @@ export const useSocialLogin = (handlers?: SocialLoginErrorHandlers) => {
       exchangeSocialToken(payload),
     onSuccess: (result) => {
       storage.setToken(result.token.accessToken);
+      storage.setPolicyAgreed(result.policyAgreed);
       setAuthenticated(true);
       setPolicyAgreed(result.policyAgreed);
 

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -1,18 +1,48 @@
 ﻿import { Suspense, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/common/header/Header";
+import { useAuthStore } from "@/store/auth";
+import { useSettingsStore } from "@/store/settings";
 import { useMyProfile } from "./components/account/hooks/useMyProfile";
 import LogoutConfirmModal from "./components/LogoutConfirmModal";
 import ProfileHeaderCard from "./components/ProfileHeaderCard";
 import { LogoutAction, WithdrawAction } from "./components/SettingsActions";
 import { SettingsSection, sections } from "./components/SettingsSectionList";
 import WithdrawConfirmModal from "./components/WithdrawConfirmModal";
+import { useLogout } from "./hooks/useLogout";
+import { useWithdraw } from "./hooks/useWithdraw";
 
 function SettingsPageInner() {
   const navigate = useNavigate();
   const [isLogoutOpen, setIsLogoutOpen] = useState(false);
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const { data: profile } = useMyProfile();
+  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
+  const setShowLogoutToast = useSettingsStore(
+    (state) => state.setShowLogoutToast
+  );
+  const setShowWithdrawSuccessModal = useSettingsStore(
+    (state) => state.setShowWithdrawSuccessModal
+  );
+
+  const logoutMutation = useLogout({
+    onSuccess: () => {
+      setIsLogoutOpen(false);
+      setShowLogoutToast(true);
+      navigate("/");
+      setTimeout(() => {
+        setAuthenticated(false);
+      }, 100);
+    },
+  });
+
+  const withdrawMutation = useWithdraw({
+    onSuccess: () => {
+      setIsWithdrawOpen(false);
+      setShowWithdrawSuccessModal(true);
+      
+    },
+  });
 
   const onNavigate = (path: string) => {
     navigate(path);
@@ -20,6 +50,14 @@ function SettingsPageInner() {
 
   const onLogout = () => setIsLogoutOpen(true);
   const onWithdraw = () => setIsWithdrawOpen(true);
+
+  const handleLogoutConfirm = () => {
+    logoutMutation.mutate();
+  };
+
+  const handleWithdrawConfirm = () => {
+    withdrawMutation.mutate();
+  };
 
   const dividerStyle = { background: "var(--MOAMOA-G-200, #EEE)" };
 
@@ -66,13 +104,13 @@ function SettingsPageInner() {
       <WithdrawConfirmModal
         open={isWithdrawOpen}
         onCancel={() => setIsWithdrawOpen(false)}
-        onConfirm={() => setIsWithdrawOpen(false)}
+        onConfirm={handleWithdrawConfirm}
       />
 
       <LogoutConfirmModal
         open={isLogoutOpen}
         onCancel={() => setIsLogoutOpen(false)}
-        onConfirm={() => setIsLogoutOpen(false)}
+        onConfirm={handleLogoutConfirm}
       />
     </div>
   );

--- a/src/pages/settings/components/LogoutToast.tsx
+++ b/src/pages/settings/components/LogoutToast.tsx
@@ -1,0 +1,24 @@
+import IcCheck from "@/assets/icons/ic_check.svg?react";
+
+interface LogoutToastProps {
+  show: boolean;
+}
+
+export default function LogoutToast({ show }: LogoutToastProps) {
+  if (!show) return null;
+
+  return (
+    <div
+      className="fixed right-0 left-0 z-50 flex justify-center"
+      style={{ bottom: "110px" }}
+    >
+      <output
+        aria-live="polite"
+        className="flex items-center gap-12 rounded-full bg-[#5D72A2] px-20 py-12"
+      >
+        <IcCheck className="h-24 w-24 shrink-0 text-white" />
+        <p className="body-4 text-white">로그아웃 되었습니다.</p>
+      </output>
+    </div>
+  );
+}

--- a/src/pages/settings/components/WithdrawSuccessModal.tsx
+++ b/src/pages/settings/components/WithdrawSuccessModal.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/common/button/Button";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function WithdrawSuccessModal({ open, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-[rgba(36,44,61,0.40)]" />
+
+      <div
+        className="relative w-full px-35"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="withdraw-success-title"
+      >
+        <div className="flex w-full flex-col items-center rounded-xl bg-white px-20 pt-28 pb-20">
+          <h2 id="withdraw-success-title" className="heading-4 text-black">
+            계정이 삭제되었어요
+          </h2>
+
+          <p className="body-2 mt-20 whitespace-pre-line text-center text-gray-600">
+            지금까지 모아모아와<br/>함께 해주셔서 감사합니다.
+          </p>
+
+          <Button
+            type="button"
+            onClick={onClose}
+            className="body-2 mt-29 rounded-xl bg-moamoa-300 px-44 py-12 text-white"
+          >
+            또 만나요!
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/settings/hooks/useLogout.ts
+++ b/src/pages/settings/hooks/useLogout.ts
@@ -1,7 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { logout } from "@/apis/auth/auth";
 import { useApiError } from "@/hooks/api/useApiError";
-import { useAuthStore } from "@/store/auth";
 
 type LogoutHandlers = {
   onSuccess?: () => void;
@@ -9,13 +8,11 @@ type LogoutHandlers = {
 
 export const useLogout = (handlers?: LogoutHandlers) => {
   const { handleError } = useApiError();
-  const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
 
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
       localStorage.clear();
-      setPolicyAgreed(null);
       handlers?.onSuccess?.();
     },
     onError: (error) => {

--- a/src/pages/settings/hooks/useLogout.ts
+++ b/src/pages/settings/hooks/useLogout.ts
@@ -1,0 +1,25 @@
+import { useMutation } from "@tanstack/react-query";
+import { logout } from "@/apis/auth/auth";
+import { useApiError } from "@/hooks/api/useApiError";
+import { useAuthStore } from "@/store/auth";
+
+type LogoutHandlers = {
+  onSuccess?: () => void;
+};
+
+export const useLogout = (handlers?: LogoutHandlers) => {
+  const { handleError } = useApiError();
+  const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      localStorage.clear();
+      setPolicyAgreed(null);
+      handlers?.onSuccess?.();
+    },
+    onError: (error) => {
+      handleError(error);
+    },
+  });
+};

--- a/src/pages/settings/hooks/useWithdraw.ts
+++ b/src/pages/settings/hooks/useWithdraw.ts
@@ -1,7 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { deleteMember } from "@/apis/profile/profile";
 import { useApiError } from "@/hooks/api/useApiError";
-import { useAuthStore } from "@/store/auth";
 
 type WithdrawHandlers = {
   onSuccess?: () => void;
@@ -9,13 +8,11 @@ type WithdrawHandlers = {
 
 export const useWithdraw = (handlers?: WithdrawHandlers) => {
   const { handleError } = useApiError();
-  const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
 
   return useMutation({
     mutationFn: deleteMember,
     onSuccess: () => {
       localStorage.clear();
-      setPolicyAgreed(null);
       handlers?.onSuccess?.();
     },
     onError: (error) => {

--- a/src/pages/settings/hooks/useWithdraw.ts
+++ b/src/pages/settings/hooks/useWithdraw.ts
@@ -1,0 +1,25 @@
+import { useMutation } from "@tanstack/react-query";
+import { deleteMember } from "@/apis/profile/profile";
+import { useApiError } from "@/hooks/api/useApiError";
+import { useAuthStore } from "@/store/auth";
+
+type WithdrawHandlers = {
+  onSuccess?: () => void;
+};
+
+export const useWithdraw = (handlers?: WithdrawHandlers) => {
+  const { handleError } = useApiError();
+  const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
+
+  return useMutation({
+    mutationFn: deleteMember,
+    onSuccess: () => {
+      localStorage.clear();
+      setPolicyAgreed(null);
+      handlers?.onSuccess?.();
+    },
+    onError: (error) => {
+      handleError(error);
+    },
+  });
+};

--- a/src/pages/splash/Start.tsx
+++ b/src/pages/splash/Start.tsx
@@ -45,7 +45,7 @@ const StartPage = ({ enableFade = true }: StartPageProps) => {
       <Button
         type="button"
         className="mt-auto mb-80 h-48 w-full rounded-lg bg-moamoa-300 py-16 font-semibold text-base text-white"
-        onClick={() => navigate("/login")}
+        onClick={() => navigate("/home")}
       >
         시작하기
       </Button>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 
 interface AuthStore {
   isAuthenticated: boolean;
@@ -10,20 +9,12 @@ interface AuthStore {
   setPolicyAgreed: (value: boolean | null) => void;
 }
 
-export const useAuthStore = create<AuthStore>()(
-  persist(
-    (set) => ({
-      isAuthenticated: false,
-      isLoading: true,
-      policyAgreed: null,
+export const useAuthStore = create<AuthStore>()((set) => ({
+  isAuthenticated: false,
+  isLoading: true,
+  policyAgreed: null,
 
-      setAuthenticated: (value) => set({ isAuthenticated: value }),
-      setLoading: (value) => set({ isLoading: value }),
-      setPolicyAgreed: (value) => set({ policyAgreed: value }),
-    }),
-    {
-      name: "auth",
-      partialize: (state) => ({ policyAgreed: state.policyAgreed }),
-    }
-  )
-);
+  setAuthenticated: (value) => set({ isAuthenticated: value }),
+  setLoading: (value) => set({ isLoading: value }),
+  setPolicyAgreed: (value) => set({ policyAgreed: value }),
+}));

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface SettingsStore {
+  showLogoutToast: boolean;
+  showWithdrawSuccessModal: boolean;
+  setShowLogoutToast: (value: boolean) => void;
+  setShowWithdrawSuccessModal: (value: boolean) => void;
+}
+
+export const useSettingsStore = create<SettingsStore>((set) => ({
+  showLogoutToast: false,
+  showWithdrawSuccessModal: false,
+  setShowLogoutToast: (value) => set({ showLogoutToast: value }),
+  setShowWithdrawSuccessModal: (value) => set({ showWithdrawSuccessModal: value }),
+}));


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #152 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
1. policyAgreed 관리 방식 변경                                                                                                                                        
                                                                                                                                                                        
  - 기존: zustand persist로 auth store 전체를 localStorage에 저장                                                                                                       
  - 변경: policyAgreed만 별도 localStorage 키로 관리
  - 이유:
    - zustand persist가 로그아웃/회원탈퇴 시에도 자동으로 auth 키를 재생성하는 문제
    - localStorage.clear() 후에도 persist가 빈 객체를 다시 저장하여 데이터 정리 불완전
  ---
  2. 기존 로그인 사용자 대응 로직

  // useAuth.ts
  const storedPolicyAgreed = storage.getPolicyAgreed();
  setPolicyAgreed(storedPolicyAgreed ?? true);  // null이면 true로 설정

  배경:
  - 이번 배포 전에 로그인한 사용자는 localStorage에 policyAgreed 키가 없음
  - 토큰은 있지만 policyAgreed가 null이면 /terms로 리다이렉트되는 문제 발생

  해결:
  - 토큰이 있으면 (= 이미 로그인했으면) policyAgreed를 true로 간주
  - 로그인 API가 policyAgreed: false를 반환하는 경우는 신규 가입자이므로 문제없음

  ---
  3. 로그아웃/회원탈퇴 네비게이션 타이밍 처리

  // SettingsPage.tsx, GlobalModals.tsx
  onSuccess: () => {
    localStorage.clear();
    navigate("/");                    // 1. 먼저 스플래시로 이동
    setTimeout(() => {                // 2. 100ms 후 인증 상태 해제
      setAuthenticated(false);
    }, 100);
  }

  이유:
  - setAuthenticated(false)를 즉시 호출하면 현재 페이지(/settings)에서 AuthGuard가 /login으로 리다이렉트
  - navigate("/")가 실행되기 전에 리다이렉트되어 스플래시 화면을 건너뜀

  ---
  4. Start 페이지 분기 로직 제거

  Before:
  onClick={() => navigate(policyAgreed ? "/home" : "/login")}

  After:
  onClick={() => navigate("/home")}  // 항상 /home, AuthGuard가 처리

  장점:
  - Start 페이지가 인증 로직을 알 필요 없음
  - AuthGuard에 모든 네비게이션 로직 집중
  - 유지보수 및 테스트 용이

  ---
  5. App.tsx 리팩토링
  - GlobalModals, GoalPopups, useAppInitializer 분리

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|영상|
|---|
|![화면 기록 2026-02-10 오후 9 52 22](https://github.com/user-attachments/assets/75266bf0-dc13-4427-b254-7afe4d79df99)|


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
1번 방식이 적절한지, 더 나은 대안이 있는지 의견 부탁드립니다.
2번  이 fallback 로직(?? true)이 안전한지 예외 케이스가 있는지 검토 부탁드립니다!