### PR TITLE
Feat: 구매 완료 모달에서 아이템 즉시 장착 기능 연결

### DIFF
--- a/src/pages/home/components/modal/PurchaseCompleteModal.tsx
+++ b/src/pages/home/components/modal/PurchaseCompleteModal.tsx
@@ -1,18 +1,21 @@
 import IcBigAcorn from "@/assets/icons/ic_big_acorn.svg?react";
 import { Button } from "@/components/common/button/Button";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
 import Modal from "./Modal";
 
 interface PurchaseCompleteModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onGoToMission: () => void;
+  onApply: () => void;
+  isLoading?: boolean;
   name: string;
 }
 
 export default function PurchaseCompleteModal({
   isOpen,
   onClose,
-  onGoToMission,
+  onApply,
+  isLoading = false,
   name,
 }: PurchaseCompleteModalProps) {
   return (
@@ -31,15 +34,17 @@ export default function PurchaseCompleteModal({
         <div className="mt-20 flex w-full gap-12">
           <Button
             onClick={onClose}
+            disabled={isLoading}
             className="body-2 rounded-lg bg-moamoa-50 px-30 py-12 text-moamoa-600"
           >
             닫기
           </Button>
           <Button
-            onClick={onGoToMission}
-            className="body-2 rounded-lg bg-moamoa-300 px-35 py-12 text-white"
+            onClick={onApply}
+            disabled={isLoading}
+            className="body-2 rounded-lg bg-moamoa-300 px-49.5 py-12 text-white"
           >
-            미션 하러가기
+            {isLoading ? <LoadingSpinner className="size-20" /> : "적용하기"}
           </Button>
         </div>
       </div>

--- a/src/pages/home/components/shop/ShopItemsGrid.tsx
+++ b/src/pages/home/components/shop/ShopItemsGrid.tsx
@@ -89,7 +89,13 @@ const ShopItemsGrid = ({ category, isBackground }: ShopItemsGridProps) => {
       <PurchaseCompleteModal
         isOpen={modalType === "complete"}
         onClose={closeModal}
-        onGoToMission={() => navigate("/search")}
+        onApply={() => {
+          if (!purchaseTarget || equipMutation.isPending) return;
+          equipMutation.mutate(purchaseTarget.itemId, {
+            onSuccess: () => closeModal(),
+          });
+        }}
+        isLoading={equipMutation.isPending}
         name={purchaseTarget?.name ?? ""}
       />
 


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #1

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 구매 완료 모달의 "적용하기" 버튼 클릭 시 탐색 화면 이동 대신 아이템 장착 API(`equipItem`)를 호출하도록 변경

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|영상|
|---|
|![bandicam 2026-02-10 22-50-14-635](https://github.com/user-attachments/assets/87868bbe-2e82-464e-81a8-ae475baf7ef2)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 장비 적용 중 로딩 상태를 시각적으로 표시하도록 개선했습니다.
  * 로딩 중 버튼 중복 클릭을 방지하기 위해 버튼을 비활성화합니다.

* **개선 사항**
  * 구매 완료 후 장비 적용 시 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->