### PR TITLE
fix: 설정페이지 회원정보수정 API 타입 수정

### DIFF
--- a/src/pages/settings/components/account/utils/profileMapper.ts
+++ b/src/pages/settings/components/account/utils/profileMapper.ts
@@ -11,8 +11,8 @@ export const toUserProfile = (p: MyProfile): UserProfile => ({
   name: p.name,
   email: p.email,
   profileId: String(p.profileImage),
-  birthDate: p.birthday.replaceAll("-", "."),
-  gender: toUiGender(p.gender),
+  birthDate: p.birthday ? p.birthday.replaceAll("-", ".") : "",
+  gender: p.gender ? toUiGender(p.gender) : "남자",
   phone: p.phoneNumber ?? "",
 });
 

--- a/src/types/profile/profile.ts
+++ b/src/types/profile/profile.ts
@@ -5,8 +5,8 @@ export interface MyProfile {
   profileImage: number;
   name: string;
   email: string;
-  birthday: string;
-  gender: MemberGender;
+  birthday: string | null;
+  gender: MemberGender | null;
   phoneNumber: string | null;
   provider: MemberProvider;
 }


### PR DESCRIPTION

## 🚀 관련 이슈


- close #178 

## 🔑 작업 내용

설정페이지 회원정보수정 API 파일 타입 수정했습니다!

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 계정 설정의 프로필에서 생일/성별 정보가 비어 있거나 누락된 경우에도 오류 없이 표시되며, 생일은 빈 값으로, 성별은 기본값으로 노출됩니다.
  * 프로필 조회·저장 과정에서 누락된 필드로 인해 발생하던 예외 가능성을 줄여 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->