### PR TITLE
Fix: 첫시도 결과 화면 출력 수정

### DIFF
--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -69,7 +69,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     if (isContentWatched) return;
     if (watchTimeoutRef.current) window.clearTimeout(watchTimeoutRef.current);
 
-    const watchDuration = mission.videoLength * 1000;
+    const watchDuration = mission.videoLength * 1;
 
     watchTimeoutRef.current = window.setTimeout(() => {
       watchMission.mutate(missionId, {
@@ -94,7 +94,9 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
       { missionId, status: "NONE" },
       {
         onSuccess: () => {
-          navigate(`/mission/quiz/${missionId}`);
+          navigate(`/mission/quiz/${missionId}`, {
+            state: { isRetry: mission.attemptCount > 0 },
+          });
         },
         onError: handleMutationError,
       }

--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -69,7 +69,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     if (isContentWatched) return;
     if (watchTimeoutRef.current) window.clearTimeout(watchTimeoutRef.current);
 
-    const watchDuration = mission.videoLength * 1;
+    const watchDuration = mission.videoLength * 1000;
 
     watchTimeoutRef.current = window.setTimeout(() => {
       watchMission.mutate(missionId, {

--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import AsyncBoundary from "@/components/AsyncBoundary";
 import Header from "@/components/common/header/Header";
 import MissionErrorToast from "@/pages/mission/components/MissionErrorToast";
@@ -39,6 +39,7 @@ function mapQuizToQuestion(quiz: Quiz) {
 
 function QuizPageContent({ missionId }: { missionId: number }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { data: mission } = useMissionDetail(missionId);
   const submitQuiz = useSubmitMissionQuiz();
   const changeMissionStatus = useChangeMissionStatus();
@@ -63,7 +64,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
 
   const feedbackTimeoutRef = useRef<number | null>(null);
 
-  const isRetry = mission.attemptCount > 0;
+  const isRetry = (location.state as { isRetry?: boolean })?.isRetry ?? mission.attemptCount > 0;
 
   const handleMutationError = useCallback((error: unknown) => {
     const apiError = error as ApiError;


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #180

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 미션 성공 시 퀴즈 시작 시 네비게이션에 재시도 상태(isRetry)를 함께 전달하도록 추가.
  * 퀴즈 페이지에서 이전 네비게이션 상태(location.state)를 우선 참조해 isRetry를 판별하도록 변경하여 뒤로 가기/종료 팝업 및 재시도 흐름의 동작을 더 일관되게 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->