### PR TITLE
Fix: 퀴즈 타입 별 도토리 개수 지정 및 기타 오류 수정

### DIFF
--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -55,6 +55,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     mission.isContentWatched
   );
   const watchTimeoutRef = useRef<number | null>(null);
+  const clickedAtRef = useRef<number | null>(null);
 
   const watchMission = useWatchMission();
   const changeMissionStatus = useChangeMissionStatus();
@@ -65,29 +66,51 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     setErrorMessage(apiError.serverMessage || "오류가 발생했습니다.");
   };
 
+  const callWatchApi = () => {
+    watchMission.mutate(missionId, {
+      onSuccess: (data) => {
+        setIsContentWatched(data.isContentWatched);
+        clickedAtRef.current = null;
+      },
+      onError: handleMutationError,
+    });
+  };
+
   const handleContentClick = () => {
     if (isContentWatched) return;
     if (watchTimeoutRef.current) window.clearTimeout(watchTimeoutRef.current);
 
     const watchDuration = mission.videoLength * 1000;
+    clickedAtRef.current = Date.now();
 
     watchTimeoutRef.current = window.setTimeout(() => {
-      watchMission.mutate(missionId, {
-        onSuccess: (data) => {
-          setIsContentWatched(data.isContentWatched);
-        },
-        onError: handleMutationError,
-      });
+      callWatchApi();
     }, watchDuration);
   };
 
   useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (
+        document.visibilityState === "visible" &&
+        clickedAtRef.current &&
+        !isContentWatched
+      ) {
+        const elapsed = Date.now() - clickedAtRef.current;
+        const watchDuration = mission.videoLength * 1000;
+        if (elapsed >= watchDuration) {
+          callWatchApi();
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       if (watchTimeoutRef.current) {
         window.clearTimeout(watchTimeoutRef.current);
       }
     };
-  }, []);
+  }, [isContentWatched, mission.videoLength]);
 
   const handleStartQuiz = () => {
     changeMissionStatus.mutate(

--- a/src/pages/mission/entry/components/MissionInfoCard.tsx
+++ b/src/pages/mission/entry/components/MissionInfoCard.tsx
@@ -39,7 +39,9 @@ export default function MissionInfoCard({
   return (
     <div className="flex w-full flex-col gap-8 rounded-xl bg-white px-23 pt-21">
       <div className="flex items-center">
-        <h2 className="heading-3 pb-4 text-center text-black">{title}</h2>
+        <h2 className="heading-3 line-clamp-2 pb-4 text-center text-black">
+          {title}
+        </h2>
       </div>
       <div className="flex items-start gap-4 self-stretch pb-16">
         {keyword.map((kw, index) => (
@@ -92,14 +94,14 @@ export default function MissionInfoCard({
         </div>
       </div>
 
-      <div className="flex w-full flex-col items-center gap-16 self-center px-30">
+      <div className="flex w-full flex-col items-center gap-16 self-center px-30 pt-30">
         <span
           className={`heading-6 flex text-center ${
             isContentWatched ? "text-moamoa-500" : "w-208 text-red-400"
           }`}
         >
           {isContentWatched ? (
-            <div className="flex flex-wrap items-center justify-center pt-30">
+            <div className="flex flex-wrap items-center justify-center">
               <span className="heading-6 whitespace-nowrap text-moamoa-400">
                 지금 퀴즈 도전하고
               </span>

--- a/src/pages/mission/goal/DailyGoalAchievement.tsx
+++ b/src/pages/mission/goal/DailyGoalAchievement.tsx
@@ -135,7 +135,7 @@ export default function DailyGoalAchievement({
         <div className="flex w-full gap-12">
           <button
             type="button"
-            onClick={() => navigate("/mypage?tab=mission")}
+            onClick={onClose}
             className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"
           >
             확인

--- a/src/pages/mission/goal/DailyGoalAchievement.tsx
+++ b/src/pages/mission/goal/DailyGoalAchievement.tsx
@@ -7,9 +7,15 @@ import IcSuccessOX from "@/assets/icons/mission/ic_success_ox.svg?react";
 import Header from "@/components/common/header/Header";
 
 const QUESTION_TYPE_LABELS: Record<string, string> = {
-  subjective: "단답형",
-  ox: "OX",
-  multiple: "객관식",
+  SHORT: "단답식",
+  OX: "OX",
+  MULTIPLE: "객관식",
+};
+
+const QUESTION_TYPE_REWARDS: Record<string, number> = {
+  OX: 3,
+  MULTIPLE: 5,
+  SHORT: 10,
 };
 
 interface QuestionResult {
@@ -19,15 +25,15 @@ interface QuestionResult {
 
 interface DailyGoalAchievementProps {
   totalAcorns: number;
+  goalReward: number;
   questionResults: QuestionResult[];
-  correctCount: number;
   onClose: () => void;
 }
 
 export default function DailyGoalAchievement({
   totalAcorns,
+  goalReward,
   questionResults,
-  correctCount,
   onClose,
 }: DailyGoalAchievementProps) {
   const navigate = useNavigate();
@@ -70,6 +76,14 @@ export default function DailyGoalAchievement({
             <div className="px-20 pb-17">
               <div className="mb-16 border-moamoa-300 border-t border-dashed" />
 
+              <div className="flex items-center justify-between py-8 pl-10">
+                <span className="body-2 text-black">일간 목표 달성</span>
+                <div className="flex items-center gap-10">
+                  <span className="body-2 text-black">+{goalReward}</span>
+                  <IcColoredAcorn className="h-24 w-24" />
+                </div>
+              </div>
+
               {questionResults.map((result, index) => (
                 <div
                   key={index}
@@ -80,7 +94,10 @@ export default function DailyGoalAchievement({
                   </span>
                   <div className="flex items-center gap-10">
                     <span className="body-2 text-black">
-                      +{result.isCorrect ? 1 : 0}
+                      +
+                      {result.isCorrect
+                        ? (QUESTION_TYPE_REWARDS[result.type] ?? 1)
+                        : 0}
                     </span>
                     <IcColoredAcorn className="h-24 w-24" />
                   </div>
@@ -92,7 +109,7 @@ export default function DailyGoalAchievement({
               <div className="flex items-center justify-between pl-30">
                 <span className="heading-3 text-black">Total</span>
                 <div className="flex items-center pr-30">
-                  <span className="heading-3 text-black">+{correctCount}</span>
+                  <span className="heading-3 text-black">+{totalAcorns}</span>
                   <IcColoredAcorn className="h-30 w-30" />
                 </div>
               </div>

--- a/src/pages/mission/goal/DailyWeeklyGoalAchievement.tsx
+++ b/src/pages/mission/goal/DailyWeeklyGoalAchievement.tsx
@@ -6,9 +6,15 @@ import IcExpand from "@/assets/icons/mission/ic_expand.svg?react";
 import IcSimple from "@/assets/icons/mission/ic_simple.svg?react";
 
 const QUESTION_TYPE_LABELS: Record<string, string> = {
-  subjective: "단답형",
-  ox: "OX",
-  multiple: "객관식",
+  SHORT: "단답식",
+  OX: "OX",
+  MULTIPLE: "객관식",
+};
+
+const QUESTION_TYPE_REWARDS: Record<string, number> = {
+  OX: 3,
+  MULTIPLE: 5,
+  SHORT: 10,
 };
 
 interface QuestionResult {
@@ -18,28 +24,26 @@ interface QuestionResult {
 
 interface DailyWeeklyGoalAchievementProps {
   totalAcorns: number;
+  goalReward: number;
   missionName: string;
   questionResults: QuestionResult[];
-  dailyBonusAcorns?: number;
-  weeklyBonusAcorns?: number;
 }
 
 export default function DailyWeeklyGoalAchievement({
   totalAcorns,
+  goalReward,
   missionName,
   questionResults,
-  dailyBonusAcorns = 1,
-  weeklyBonusAcorns = 1,
 }: DailyWeeklyGoalAchievementProps) {
   const navigate = useNavigate();
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const [isMissionOpen, setIsMissionOpen] = useState(false);
 
   const missionAcorns = questionResults.reduce(
-    (sum, r) => sum + (r.isCorrect ? 1 : 0),
+    (sum, r) => sum + (r.isCorrect ? (QUESTION_TYPE_REWARDS[r.type] ?? 1) : 0),
     0
   );
-  const grandTotal = missionAcorns + dailyBonusAcorns + weeklyBonusAcorns;
+  const grandTotal = totalAcorns;
 
   return (
     <div className="relative -mb-96 flex min-h-screen flex-col items-center">
@@ -83,8 +87,8 @@ export default function DailyWeeklyGoalAchievement({
                   className="flex w-full items-center justify-between py-8"
                   onClick={() => setIsMissionOpen((prev) => !prev)}
                 >
-                  <span className="body-2 text-black">{missionName}</span>
-                  <div className="flex items-center">
+                  <span className="body-2 line-clamp-2 min-w-0 flex-1 text-left text-black">{missionName}</span>
+                  <div className="flex shrink-0 items-center">
                     <span className="body-2 text-black">+{missionAcorns}</span>
                     <IcColoredAcorn className="h-24 w-24" />
                     <span className="w-12" />
@@ -108,7 +112,7 @@ export default function DailyWeeklyGoalAchievement({
                         </span>
                         <div className="flex items-center">
                           <span className="body-4 text-gray-500">
-                            +{result.isCorrect ? 1 : 0}
+                            +{result.isCorrect ? (QUESTION_TYPE_REWARDS[result.type] ?? 1) : 0}
                           </span>
                           <IcColoredAcorn className="h-24 w-24" />
                         </div>
@@ -119,19 +123,9 @@ export default function DailyWeeklyGoalAchievement({
               </div>
 
               <div className="flex items-center justify-between py-8 pl-10">
-                <span className="body-2 text-black">일간 목표 달성</span>
+                <span className="body-2 text-black">목표 달성 보너스</span>
                 <div className="flex items-center gap-10">
-                  <span className="body-2 text-black">+{dailyBonusAcorns}</span>
-                  <IcColoredAcorn className="h-24 w-24" />
-                </div>
-              </div>
-
-              <div className="flex items-center justify-between py-8 pl-10">
-                <span className="body-2 text-black">주간 목표 달성</span>
-                <div className="flex items-center gap-10">
-                  <span className="body-2 text-black">
-                    +{weeklyBonusAcorns}
-                  </span>
+                  <span className="body-2 text-black">+{goalReward}</span>
                   <IcColoredAcorn className="h-24 w-24" />
                 </div>
               </div>

--- a/src/pages/mission/goal/DailyWeeklyGoalAchievement.tsx
+++ b/src/pages/mission/goal/DailyWeeklyGoalAchievement.tsx
@@ -27,6 +27,7 @@ interface DailyWeeklyGoalAchievementProps {
   goalReward: number;
   missionName: string;
   questionResults: QuestionResult[];
+  onConfirm: () => void;
 }
 
 export default function DailyWeeklyGoalAchievement({
@@ -34,6 +35,7 @@ export default function DailyWeeklyGoalAchievement({
   goalReward,
   missionName,
   questionResults,
+  onConfirm,
 }: DailyWeeklyGoalAchievementProps) {
   const navigate = useNavigate();
   const [isDetailOpen, setIsDetailOpen] = useState(false);
@@ -152,7 +154,7 @@ export default function DailyWeeklyGoalAchievement({
         <div className="flex w-full gap-12">
           <button
             type="button"
-            onClick={() => navigate("/mypage?tab=mission")}
+            onClick={onConfirm}
             className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"
           >
             확인

--- a/src/pages/mission/goal/WeeklyGoalAchievement.tsx
+++ b/src/pages/mission/goal/WeeklyGoalAchievement.tsx
@@ -8,9 +8,15 @@ import IcSimple from "@/assets/icons/mission/ic_simple.svg?react";
 import Header from "@/components/common/header/Header";
 
 const QUESTION_TYPE_LABELS: Record<string, string> = {
-  subjective: "단답형",
-  ox: "OX",
-  multiple: "객관식",
+  SHORT: "단답식",
+  OX: "OX",
+  MULTIPLE: "객관식",
+};
+
+const QUESTION_TYPE_REWARDS: Record<string, number> = {
+  OX: 3,
+  MULTIPLE: 5,
+  SHORT: 10,
 };
 
 interface QuestionResult {
@@ -20,23 +26,21 @@ interface QuestionResult {
 
 interface WeeklyGoalAchievementProps {
   totalAcorns: number;
+  goalReward: number;
   questionResults: QuestionResult[];
-  correctCount: number;
-  weeklyBonusAcorns?: number;
   onClose: () => void;
 }
 
 export default function WeeklyGoalAchievement({
   totalAcorns,
+  goalReward,
   questionResults,
-  correctCount,
-  weeklyBonusAcorns = 1,
   onClose,
 }: WeeklyGoalAchievementProps) {
   const navigate = useNavigate();
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
-  const grandTotal = correctCount + weeklyBonusAcorns;
+  const grandTotal = totalAcorns;
 
   return (
     <div className="relative -mb-96 flex min-h-screen flex-col items-center">
@@ -83,7 +87,7 @@ export default function WeeklyGoalAchievement({
                   <span className="body-2 text-black">주간 목표 달성</span>
                   <div className="flex items-center gap-10">
                     <span className="body-2 text-black">
-                      +{weeklyBonusAcorns}
+                      +{goalReward}
                     </span>
                     <IcColoredAcorn className="h-24 w-24" />
                   </div>
@@ -99,7 +103,7 @@ export default function WeeklyGoalAchievement({
                     </span>
                     <div className="flex items-center gap-10">
                       <span className="body-2 text-black">
-                        +{result.isCorrect ? 1 : 0}
+                        +{result.isCorrect ? (QUESTION_TYPE_REWARDS[result.type] ?? 1) : 0}
                       </span>
                       <IcColoredAcorn className="h-24 w-24" />
                     </div>

--- a/src/pages/mission/goal/WeeklyGoalAchievement.tsx
+++ b/src/pages/mission/goal/WeeklyGoalAchievement.tsx
@@ -143,7 +143,7 @@ export default function WeeklyGoalAchievement({
         <div className="flex w-full gap-12">
           <button
             type="button"
-            onClick={() => navigate("/mypage?tab=mission")}
+            onClick={onClose}
             className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"
           >
             확인

--- a/src/pages/mission/hooks/useMutation/useSubmitMissionQuiz.ts
+++ b/src/pages/mission/hooks/useMutation/useSubmitMissionQuiz.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { submitMissionQuiz } from "@/apis/missions/missionAction";
 import { useApiError } from "@/hooks/api/useApiError";
 import type { ApiError } from "@/types/api/api";
@@ -11,10 +11,16 @@ interface SubmitMissionQuizParams {
 
 export const useSubmitMissionQuiz = () => {
   const { handleError } = useApiError();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ missionId, submissions }: SubmitMissionQuizParams) =>
       submitMissionQuiz(missionId, submissions),
+    onSuccess: (_data, { missionId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["missions", "detail", missionId],
+      });
+    },
     onError: (error: ApiError) => handleError(error),
   });
 };

--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -57,6 +57,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
   const [quizResult, setQuizResult] = useState<{
     isSuccess: boolean;
     totalAcorns: number;
+    goalReward: number;
     isDailyGoalAchieved: boolean;
     isWeeklyGoalAchieved: boolean;
   } | null>(null);
@@ -191,6 +192,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
               setQuizResult({
                 isSuccess: data.isSuccess,
                 totalAcorns: data.totalReward,
+                goalReward: data.goalReward,
                 isDailyGoalAchieved: data.dailyGoalAchieved,
                 isWeeklyGoalAchieved: data.weeklyGoalAchieved,
               });
@@ -227,14 +229,15 @@ function QuizPageContent({ missionId }: { missionId: number }) {
     return (
       <MissionResult
         totalAcorns={quizResult.totalAcorns}
+        goalReward={quizResult.goalReward}
         questionResults={questionResults}
         correctCount={correctCount}
         totalQuestions={mission.quizzes.length}
-        missionName={mission.interest}
+        missionName={mission.title}
         isDailyGoalAchieved={quizResult.isDailyGoalAchieved}
         isWeeklyGoalAchieved={quizResult.isWeeklyGoalAchieved}
         onRetryWrong={() => {
-          navigate(`/mission/entry/${missionId}`);
+          navigate(`/mission/${missionId}`);
         }}
       />
     );

--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -187,7 +187,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
         {
           onSuccess: (data) => {
             if (isRetry) {
-              navigate("/mypage?tab=mission");
+              navigate("/mypage?tab=mission", { replace: true });
             } else {
               setQuizResult({
                 isSuccess: data.isSuccess,
@@ -237,7 +237,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
         isDailyGoalAchieved={quizResult.isDailyGoalAchieved}
         isWeeklyGoalAchieved={quizResult.isWeeklyGoalAchieved}
         onRetryWrong={() => {
-          navigate(`/mission/${missionId}`);
+          navigate(`/mission/${missionId}`, { replace: true });
         }}
       />
     );

--- a/src/pages/mission/quiz/components/MissionResult.tsx
+++ b/src/pages/mission/quiz/components/MissionResult.tsx
@@ -15,6 +15,12 @@ const QUESTION_TYPE_LABELS: Record<string, string> = {
   MULTIPLE: "객관식",
 };
 
+const QUESTION_TYPE_REWARDS: Record<string, number> = {
+  OX: 3,
+  MULTIPLE: 5,
+  SHORT: 10,
+};
+
 interface QuestionResult {
   type: string;
   isCorrect: boolean;
@@ -22,6 +28,7 @@ interface QuestionResult {
 
 interface MissionResultProps {
   totalAcorns: number;
+  goalReward: number;
   questionResults: QuestionResult[];
   correctCount: number;
   totalQuestions: number;
@@ -33,6 +40,7 @@ interface MissionResultProps {
 
 export default function MissionResult({
   totalAcorns,
+  goalReward,
   questionResults,
   correctCount,
   totalQuestions,
@@ -58,6 +66,7 @@ export default function MissionResult({
       return (
         <DailyWeeklyGoalAchievement
           totalAcorns={totalAcorns}
+          goalReward={goalReward}
           missionName={missionName}
           questionResults={questionResults}
         />
@@ -67,8 +76,8 @@ export default function MissionResult({
       return (
         <DailyGoalAchievement
           totalAcorns={totalAcorns}
+          goalReward={goalReward}
           questionResults={questionResults}
-          correctCount={correctCount}
           onClose={() => navigate("/home")}
         />
       );
@@ -77,8 +86,8 @@ export default function MissionResult({
       return (
         <WeeklyGoalAchievement
           totalAcorns={totalAcorns}
+          goalReward={goalReward}
           questionResults={questionResults}
-          correctCount={correctCount}
           onClose={() => navigate("/home")}
         />
       );
@@ -119,7 +128,10 @@ export default function MissionResult({
               </span>
               <div className="flex items-center gap-10">
                 <span className="body-2 text-black">
-                  +{result.isCorrect ? 1 : 0}
+                  +
+                  {result.isCorrect
+                    ? (QUESTION_TYPE_REWARDS[result.type] ?? 1)
+                    : 0}
                 </span>
                 <IcColoredAcorn className="h-24 w-24" />
               </div>
@@ -131,7 +143,7 @@ export default function MissionResult({
           <div className="flex items-center justify-between pl-30">
             <span className="heading-3 text-black">Total</span>
             <div className="flex items-center gap-10 pr-30">
-              <span className="heading-3 text-black">+{correctCount}</span>
+              <span className="heading-3 text-black">+{totalAcorns}</span>
               <IcColoredAcorn className="h-30 w-30" />
             </div>
           </div>
@@ -168,14 +180,20 @@ export default function MissionResult({
             <>
               <button
                 type="button"
-                onClick={() => navigate("/search")}
+                onClick={() => {
+                  if (isDailyGoalAchieved || isWeeklyGoalAchieved) {
+                    setShowGoalScreen(true);
+                  } else {
+                    navigate("/search");
+                  }
+                }}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"
               >
                 미션 탐색
               </button>
               <button
                 type="button"
-                onClick={() => navigate("/home")}
+                onClick={handleExit}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-300 py-12 text-white"
               >
                 상점으로
@@ -185,7 +203,7 @@ export default function MissionResult({
             <>
               <button
                 type="button"
-                onClick={() => navigate("/home")}
+                onClick={handleExit}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"
               >
                 상점으로

--- a/src/pages/mission/quiz/components/MissionResult.tsx
+++ b/src/pages/mission/quiz/components/MissionResult.tsx
@@ -63,9 +63,9 @@ export default function MissionResult({
 
   const handleExit = () => {
     if (hasGoal) {
-      showGoalThen(() => navigate("/home"));
+      showGoalThen(() => navigate("/home", { replace: true }));
     } else {
-      navigate("/home");
+      navigate("/home", { replace: true });
     }
   };
 
@@ -191,9 +191,9 @@ export default function MissionResult({
                 type="button"
                 onClick={() => {
                   if (hasGoal) {
-                    showGoalThen(() => navigate("/search"));
+                    showGoalThen(() => navigate("/search", { replace: true }));
                   } else {
-                    navigate("/search");
+                    navigate("/search", { replace: true });
                   }
                 }}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"

--- a/src/pages/mission/quiz/components/MissionResult.tsx
+++ b/src/pages/mission/quiz/components/MissionResult.tsx
@@ -52,16 +52,24 @@ export default function MissionResult({
   const navigate = useNavigate();
   const isAllCorrect = correctCount === totalQuestions;
   const [showGoalScreen, setShowGoalScreen] = useState(false);
+  const [goalRedirect, setGoalRedirect] = useState<(() => void) | null>(null);
+
+  const hasGoal = isDailyGoalAchieved || isWeeklyGoalAchieved;
+
+  const showGoalThen = (redirect: () => void) => {
+    setGoalRedirect(() => redirect);
+    setShowGoalScreen(true);
+  };
 
   const handleExit = () => {
-    if (isDailyGoalAchieved || isWeeklyGoalAchieved) {
-      setShowGoalScreen(true);
+    if (hasGoal) {
+      showGoalThen(() => navigate("/home"));
     } else {
       navigate("/home");
     }
   };
 
-  if (showGoalScreen) {
+  if (showGoalScreen && goalRedirect) {
     if (isDailyGoalAchieved && isWeeklyGoalAchieved) {
       return (
         <DailyWeeklyGoalAchievement
@@ -69,6 +77,7 @@ export default function MissionResult({
           goalReward={goalReward}
           missionName={missionName}
           questionResults={questionResults}
+          onConfirm={goalRedirect}
         />
       );
     }
@@ -78,7 +87,7 @@ export default function MissionResult({
           totalAcorns={totalAcorns}
           goalReward={goalReward}
           questionResults={questionResults}
-          onClose={() => navigate("/home")}
+          onClose={goalRedirect}
         />
       );
     }
@@ -88,7 +97,7 @@ export default function MissionResult({
           totalAcorns={totalAcorns}
           goalReward={goalReward}
           questionResults={questionResults}
-          onClose={() => navigate("/home")}
+          onClose={goalRedirect}
         />
       );
     }
@@ -181,8 +190,8 @@ export default function MissionResult({
               <button
                 type="button"
                 onClick={() => {
-                  if (isDailyGoalAchieved || isWeeklyGoalAchieved) {
-                    setShowGoalScreen(true);
+                  if (hasGoal) {
+                    showGoalThen(() => navigate("/search"));
                   } else {
                     navigate("/search");
                   }
@@ -210,7 +219,13 @@ export default function MissionResult({
               </button>
               <button
                 type="button"
-                onClick={onRetryWrong}
+                onClick={() => {
+                  if (hasGoal) {
+                    showGoalThen(onRetryWrong);
+                  } else {
+                    onRetryWrong();
+                  }
+                }}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-300 py-12 text-white"
               >
                 오답 풀기


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #184

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->

- 퀴즈 타입별 도토리 획득 개수 지정
- 퀴즈 제출 후 캐시 무효화
- 영상 시청이 유튜브 어플로 자동으로 넘어갈 때, 영상 시청 완료 파악 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 문제 유형별 차등 보상(단답/객관식/OX) 적용 및 목표 보상(goalReward) 노출
  * 목표 달성 전용 화면과 목표 기반 확인 흐름(확인 버튼이 목표 핸들러로 작동)

* **버그 수정**
  * 미션 정보 카드 레이아웃·세로 간격 조정
  * 결과 화면에서 미션 이름 소스 수정 및 재시도 네비게이션 경로 개선

* **리팩토링**
  * 보상 집계 기준을 총 획득 보상(totalAcorns)으로 변경
  * 콘텐츠 시청 추적 로직(클릭 기반 지연 호출·포커스 복귀 처리) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->