### PR TITLE
Fix: 목표 달성 모달 조건 변경

### DIFF
--- a/src/pages/mission/quiz/components/MissionResult.tsx
+++ b/src/pages/mission/quiz/components/MissionResult.tsx
@@ -54,7 +54,7 @@ export default function MissionResult({
   const [showGoalScreen, setShowGoalScreen] = useState(false);
   const [goalRedirect, setGoalRedirect] = useState<(() => void) | null>(null);
 
-  const hasGoal = isDailyGoalAchieved || isWeeklyGoalAchieved;
+  const hasGoal = goalReward > 0;
 
   const showGoalThen = (redirect: () => void) => {
     setGoalRedirect(() => redirect);


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #186 
## 🔑 작업 내용

- 목표 달성 모달 조건을 goalReward > 0;로 변경하여 최신 상태에서만 달성 페이지가 뜨도록 수정
