### PR TITLE
Fix: 크롬 빈 탭, 재시작 시 진입 화면 수정 및 목표 달성 시 미션 결과 화면 건너뛰기

### DIFF
--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -56,6 +56,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
   );
   const watchTimeoutRef = useRef<number | null>(null);
   const clickedAtRef = useRef<number | null>(null);
+  const popupRef = useRef<Window | null>(null);
 
   const watchMission = useWatchMission();
   const changeMissionStatus = useChangeMissionStatus();
@@ -80,25 +81,66 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     if (isContentWatched) return;
     if (watchTimeoutRef.current) window.clearTimeout(watchTimeoutRef.current);
 
+    const now = Date.now();
     const watchDuration = mission.videoLength * 1000;
-    clickedAtRef.current = Date.now();
+    clickedAtRef.current = now;
+
+    sessionStorage.setItem("missionReturnUrl", `/mission/${missionId}`);
+    sessionStorage.setItem("missionClickedAt", String(now));
+
+    popupRef.current = window.open(mission.videoUrl, "_blank");
 
     watchTimeoutRef.current = window.setTimeout(() => {
       callWatchApi();
+      sessionStorage.removeItem("missionClickedAt");
     }, watchDuration);
   };
 
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (
-        document.visibilityState === "visible" &&
-        clickedAtRef.current &&
-        !isContentWatched
-      ) {
-        const elapsed = Date.now() - clickedAtRef.current;
+    if (!isContentWatched) {
+      const savedClickedAt = sessionStorage.getItem("missionClickedAt");
+      if (savedClickedAt) {
+        const elapsed = Date.now() - Number(savedClickedAt);
         const watchDuration = mission.videoLength * 1000;
         if (elapsed >= watchDuration) {
+          sessionStorage.removeItem("missionClickedAt");
+          sessionStorage.removeItem("missionReturnUrl");
           callWatchApi();
+        } else {
+          clickedAtRef.current = Number(savedClickedAt);
+          watchTimeoutRef.current = window.setTimeout(() => {
+            callWatchApi();
+            sessionStorage.removeItem("missionClickedAt");
+            sessionStorage.removeItem("missionReturnUrl");
+          }, watchDuration - elapsed);
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        const isMobileChrome =
+          (/Android/i.test(navigator.userAgent) &&
+            /Chrome/i.test(navigator.userAgent)) ||
+          (/iPhone|iPad/i.test(navigator.userAgent) &&
+            /CriOS/i.test(navigator.userAgent));
+        if (isMobileChrome && popupRef.current && !popupRef.current.closed) {
+          try {
+            popupRef.current.close();
+          } catch {}
+          popupRef.current = null;
+        }
+
+        if (clickedAtRef.current && !isContentWatched) {
+          const elapsed = Date.now() - clickedAtRef.current;
+          const watchDuration = mission.videoLength * 1000;
+          if (elapsed >= watchDuration) {
+            callWatchApi();
+            sessionStorage.removeItem("missionClickedAt");
+            sessionStorage.removeItem("missionReturnUrl");
+          }
         }
       }
     };

--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -90,6 +90,14 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
 
     popupRef.current = window.open(mission.videoUrl, "_blank");
 
+    if (!popupRef.current) {
+      // 팝업이 차단된 경우: 타이머를 시작하지 않고 사용자에게 안내
+      sessionStorage.removeItem("missionClickedAt");
+      sessionStorage.removeItem("missionReturnUrl");
+      clickedAtRef.current = null;
+      setErrorMessage("팝업이 차단되었습니다. 팝업 허용 후 다시 시도해주세요.");
+      return;
+    }
     watchTimeoutRef.current = window.setTimeout(() => {
       callWatchApi();
       sessionStorage.removeItem("missionClickedAt");

--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -93,6 +93,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     watchTimeoutRef.current = window.setTimeout(() => {
       callWatchApi();
       sessionStorage.removeItem("missionClickedAt");
+      sessionStorage.removeItem("missionReturnUrl");
     }, watchDuration);
   };
 

--- a/src/pages/mission/entry/components/MissionInfoCard.tsx
+++ b/src/pages/mission/entry/components/MissionInfoCard.tsx
@@ -32,7 +32,6 @@ export default function MissionInfoCard({
   const thumbnailUrl = getYoutubeThumbnail(videoUrl);
 
   const handleContentClick = () => {
-    window.open(videoUrl, "_blank", "noopener,noreferrer");
     onContentClick();
   };
 

--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import AsyncBoundary from "@/components/AsyncBoundary";
 import Header from "@/components/common/header/Header";
+import DailyGoalAchievement from "@/pages/mission/goal/DailyGoalAchievement";
+import DailyWeeklyGoalAchievement from "@/pages/mission/goal/DailyWeeklyGoalAchievement";
+import WeeklyGoalAchievement from "@/pages/mission/goal/WeeklyGoalAchievement";
 import MissionErrorToast from "@/pages/mission/components/MissionErrorToast";
 import { useChangeMissionStatus } from "@/pages/mission/hooks/useMutation/useChangeMissionStatus";
 import { useSubmitMissionQuiz } from "@/pages/mission/hooks/useMutation/useSubmitMissionQuiz";
@@ -54,6 +57,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
   const [isAnimating, setIsAnimating] = useState(false);
   const [showQuitPopup, setShowQuitPopup] = useState(false);
   const [showMissionResult, setShowMissionResult] = useState(false);
+  const [showGoalAchievement, setShowGoalAchievement] = useState(false);
   const [quizResult, setQuizResult] = useState<{
     isSuccess: boolean;
     totalAcorns: number;
@@ -197,7 +201,11 @@ function QuizPageContent({ missionId }: { missionId: number }) {
                 isWeeklyGoalAchieved: data.weeklyGoalAchieved,
               });
               setShowFeedback(false);
-              setShowMissionResult(true);
+              if (data.goalReward > 0) {
+                setShowGoalAchievement(true);
+              } else {
+                setShowMissionResult(true);
+              }
             }
           },
           onError: handleMutationError,
@@ -219,6 +227,46 @@ function QuizPageContent({ missionId }: { missionId: number }) {
     return userInput.trim() === "";
   };
 
+  if (showGoalAchievement && quizResult) {
+    const questionResults = answers.map((a) => ({
+      type: mission.quizzes.find((q) => q.quizId === a.quizId)?.type || "",
+      isCorrect: a.isCorrect,
+    }));
+    const goToMyAcorn = () => navigate("/mypage?tab=acorn", { replace: true });
+
+    if (quizResult.isDailyGoalAchieved && quizResult.isWeeklyGoalAchieved) {
+      return (
+        <DailyWeeklyGoalAchievement
+          totalAcorns={quizResult.totalAcorns}
+          goalReward={quizResult.goalReward}
+          missionName={mission.title}
+          questionResults={questionResults}
+          onConfirm={goToMyAcorn}
+        />
+      );
+    }
+    if (quizResult.isDailyGoalAchieved) {
+      return (
+        <DailyGoalAchievement
+          totalAcorns={quizResult.totalAcorns}
+          goalReward={quizResult.goalReward}
+          questionResults={questionResults}
+          onClose={goToMyAcorn}
+        />
+      );
+    }
+    if (quizResult.isWeeklyGoalAchieved) {
+      return (
+        <WeeklyGoalAchievement
+          totalAcorns={quizResult.totalAcorns}
+          goalReward={quizResult.goalReward}
+          questionResults={questionResults}
+          onClose={goToMyAcorn}
+        />
+      );
+    }
+  }
+
   if (showMissionResult && quizResult) {
     const correctCount = answers.filter((a) => a.isCorrect).length;
     const questionResults = answers.map((a) => ({
@@ -229,13 +277,9 @@ function QuizPageContent({ missionId }: { missionId: number }) {
     return (
       <MissionResult
         totalAcorns={quizResult.totalAcorns}
-        goalReward={quizResult.goalReward}
         questionResults={questionResults}
         correctCount={correctCount}
         totalQuestions={mission.quizzes.length}
-        missionName={mission.title}
-        isDailyGoalAchieved={quizResult.isDailyGoalAchieved}
-        isWeeklyGoalAchieved={quizResult.isWeeklyGoalAchieved}
         onRetryWrong={() => {
           navigate(`/mission/${missionId}`, { replace: true });
         }}

--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
+import {
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
 import AsyncBoundary from "@/components/AsyncBoundary";
 import Header from "@/components/common/header/Header";
+import MissionErrorToast from "@/pages/mission/components/MissionErrorToast";
 import DailyGoalAchievement from "@/pages/mission/goal/DailyGoalAchievement";
 import DailyWeeklyGoalAchievement from "@/pages/mission/goal/DailyWeeklyGoalAchievement";
 import WeeklyGoalAchievement from "@/pages/mission/goal/WeeklyGoalAchievement";
-import MissionErrorToast from "@/pages/mission/components/MissionErrorToast";
 import { useChangeMissionStatus } from "@/pages/mission/hooks/useMutation/useChangeMissionStatus";
 import { useSubmitMissionQuiz } from "@/pages/mission/hooks/useMutation/useSubmitMissionQuiz";
 import { useMissionDetail } from "@/pages/mission/hooks/useQuery/useMissionDetail";
@@ -69,7 +74,9 @@ function QuizPageContent({ missionId }: { missionId: number }) {
 
   const feedbackTimeoutRef = useRef<number | null>(null);
 
-  const isRetry = (location.state as { isRetry?: boolean })?.isRetry ?? mission.attemptCount > 0;
+  const isRetry =
+    (location.state as { isRetry?: boolean })?.isRetry ??
+    mission.attemptCount > 0;
 
   const handleMutationError = useCallback((error: unknown) => {
     const apiError = error as ApiError;
@@ -201,7 +208,10 @@ function QuizPageContent({ missionId }: { missionId: number }) {
                 isWeeklyGoalAchieved: data.weeklyGoalAchieved,
               });
               setShowFeedback(false);
-              if (data.goalReward > 0) {
+              if (
+                data.goalReward > 0 &&
+                (data.dailyGoalAchieved || data.weeklyGoalAchieved)
+              ) {
                 setShowGoalAchievement(true);
               } else {
                 setShowMissionResult(true);

--- a/src/pages/mission/quiz/components/MissionResult.tsx
+++ b/src/pages/mission/quiz/components/MissionResult.tsx
@@ -1,13 +1,9 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import IcAllCorrect from "@/assets/icons/mission/ic_all_correct.svg?react";
 import IcColoredAcorn from "@/assets/icons/mission/ic_colored_acorn.svg?react";
 import IcResultHands from "@/assets/icons/mission/ic_result_fail_hands.svg?react";
 import IcResultSquirrel from "@/assets/icons/mission/ic_result_fail_squirrel.svg?react";
 import Header from "@/components/common/header/Header";
-import DailyGoalAchievement from "@/pages/mission/goal/DailyGoalAchievement";
-import DailyWeeklyGoalAchievement from "@/pages/mission/goal/DailyWeeklyGoalAchievement";
-import WeeklyGoalAchievement from "@/pages/mission/goal/WeeklyGoalAchievement";
 
 const QUESTION_TYPE_LABELS: Record<string, string> = {
   SHORT: "단답식",
@@ -28,80 +24,25 @@ interface QuestionResult {
 
 interface MissionResultProps {
   totalAcorns: number;
-  goalReward: number;
   questionResults: QuestionResult[];
   correctCount: number;
   totalQuestions: number;
-  isDailyGoalAchieved?: boolean;
-  isWeeklyGoalAchieved?: boolean;
-  missionName?: string;
   onRetryWrong: () => void;
 }
 
 export default function MissionResult({
   totalAcorns,
-  goalReward,
   questionResults,
   correctCount,
   totalQuestions,
-  isDailyGoalAchieved = false,
-  isWeeklyGoalAchieved = false,
-  missionName = "",
   onRetryWrong,
 }: MissionResultProps) {
   const navigate = useNavigate();
   const isAllCorrect = correctCount === totalQuestions;
-  const [showGoalScreen, setShowGoalScreen] = useState(false);
-  const [goalRedirect, setGoalRedirect] = useState<(() => void) | null>(null);
-
-  const hasGoal = goalReward > 0;
-
-  const showGoalThen = (redirect: () => void) => {
-    setGoalRedirect(() => redirect);
-    setShowGoalScreen(true);
-  };
 
   const handleExit = () => {
-    if (hasGoal) {
-      showGoalThen(() => navigate("/home", { replace: true }));
-    } else {
-      navigate("/home", { replace: true });
-    }
+    navigate("/home", { replace: true });
   };
-
-  if (showGoalScreen && goalRedirect) {
-    if (isDailyGoalAchieved && isWeeklyGoalAchieved) {
-      return (
-        <DailyWeeklyGoalAchievement
-          totalAcorns={totalAcorns}
-          goalReward={goalReward}
-          missionName={missionName}
-          questionResults={questionResults}
-          onConfirm={goalRedirect}
-        />
-      );
-    }
-    if (isDailyGoalAchieved) {
-      return (
-        <DailyGoalAchievement
-          totalAcorns={totalAcorns}
-          goalReward={goalReward}
-          questionResults={questionResults}
-          onClose={goalRedirect}
-        />
-      );
-    }
-    if (isWeeklyGoalAchieved) {
-      return (
-        <WeeklyGoalAchievement
-          totalAcorns={totalAcorns}
-          goalReward={goalReward}
-          questionResults={questionResults}
-          onClose={goalRedirect}
-        />
-      );
-    }
-  }
 
   return (
     <div className="relative -mb-96 flex min-h-screen flex-col items-center">
@@ -189,13 +130,7 @@ export default function MissionResult({
             <>
               <button
                 type="button"
-                onClick={() => {
-                  if (hasGoal) {
-                    showGoalThen(() => navigate("/search", { replace: true }));
-                  } else {
-                    navigate("/search", { replace: true });
-                  }
-                }}
+                onClick={() => navigate("/search", { replace: true })}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-50 py-12 text-moamoa-600"
               >
                 미션 탐색
@@ -219,13 +154,7 @@ export default function MissionResult({
               </button>
               <button
                 type="button"
-                onClick={() => {
-                  if (hasGoal) {
-                    showGoalThen(onRetryWrong);
-                  } else {
-                    onRetryWrong();
-                  }
-                }}
+                onClick={onRetryWrong}
                 className="body-2-1 h-50 flex-1 rounded-xl bg-moamoa-300 py-12 text-white"
               >
                 오답 풀기

--- a/src/pages/mission/quiz/components/QuizAnswer.tsx
+++ b/src/pages/mission/quiz/components/QuizAnswer.tsx
@@ -25,7 +25,7 @@ export default function QuizAnswer({
           value={userInput}
           onChange={(e) => onInputChange(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter") {
+            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
               e.preventDefault();
               e.currentTarget.blur();
             }

--- a/src/pages/mission/quiz/components/QuizAnswer.tsx
+++ b/src/pages/mission/quiz/components/QuizAnswer.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import IcOxO from "@/assets/icons/mission/ic_ox_o.svg?react";
 import IcOxX from "@/assets/icons/mission/ic_ox_x.svg?react";
 
@@ -18,6 +19,8 @@ export default function QuizAnswer({
   onInputChange,
   onOptionSelect,
 }: QuizAnswerProps) {
+  const shouldBlurRef = useRef(false);
+
   if (questionType === "subjective") {
     return (
       <div className="pt-39">
@@ -25,8 +28,18 @@ export default function QuizAnswer({
           value={userInput}
           onChange={(e) => onInputChange(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+            if (e.key === "Enter") {
               e.preventDefault();
+              if (e.nativeEvent.isComposing) {
+                shouldBlurRef.current = true;
+              } else {
+                e.currentTarget.blur();
+              }
+            }
+          }}
+          onCompositionEnd={(e) => {
+            if (shouldBlurRef.current) {
+              shouldBlurRef.current = false;
               e.currentTarget.blur();
             }
           }}

--- a/src/pages/splash/Splash.tsx
+++ b/src/pages/splash/Splash.tsx
@@ -12,7 +12,13 @@ const SplashPage = () => {
     if (isLoading) return;
     let exitTimer = 0;
     let timer = 0;
-    const targetPath = isAuthenticated ? "/home" : "/start";
+    const returnUrl = sessionStorage.getItem("missionReturnUrl");
+    if (returnUrl) {
+      sessionStorage.removeItem("missionReturnUrl");
+    }
+    const targetPath = isAuthenticated
+      ? (returnUrl || "/home")
+      : "/start";
 
     const raf = window.requestAnimationFrame(() => {
       exitTimer = window.setTimeout(() => {


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #194

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 모바일 크롬에서 미션 영상 시청 후, 재진입 시 빈 화면(흰색 창) 제거하고 바로 미션 진입 페이지로 이동되게 수정
- 영상 시청 후 돌아왔을 때, 백그라운드 새로고침되어 /start부터 실행되는 문제 완화
- 불필요하게 미션 페이지로 리다이렉트될 상황 고려하여 수정
- 목표 달성 시, 미션 결과 화면 스킵 하고 달성 화면으로 보여줌
- 목표 달성 화면에서 확인 버튼 클릭 시, 마이페이지의 내 도토리 탭으로 이동되게 수정




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 퀴즈 완료 흐름에 일간/주간 목표별 축하 화면을 도입해 달성 유형에 따라 별도 경험 제공.
  * 완료 화면 단순화로 이동 동작이 일관되게 동작하도록 개선.

* **Bug Fixes**
  * 동영상 팝업 동작을 세션에 복원·지속하고 모바일 브라우저 가시성 변화에 대응하도록 개선.
  * 팝업 차단 시 오류 처리 개선 및 이전 클릭 복원 시점에 따른 완료 호출 보장.
  * 시작 화면이 이전 복귀 URL을 우선 사용하도록 수정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->