### PR TITLE
Fix: 1차 테스트 개선 사항 수정

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "/",
   "short_name": "모아모아",
-  "name": "모아모아 프로젝트",
+  "name": "모아모아",
   "display": "standalone",
   "orientation": "portrait",
   "scope": "/",

--- a/src/hooks/attendance/useAttendanceCheck.ts
+++ b/src/hooks/attendance/useAttendanceCheck.ts
@@ -38,7 +38,7 @@ export const useAttendanceCheck = () => {
     },
   });
 
-  const handleCheckAttendance = async () => {
+  const handleCheckAttendance = async (): Promise<boolean> => {
     const currentAttendanceData = useAttendanceStore.getState().attendanceData;
 
     // 이미 오늘 체크했지만 store에 데이터가 없는 경우 (앱 재시작)
@@ -52,13 +52,19 @@ export const useAttendanceCheck = () => {
       } catch (error) {
         console.error("출석 정보 가져오기 실패 (앱 재시작): ", error);
       }
-      return;
+      return false;
     }
 
     if (attendanceCache.hasCheckedToday() || checkMutation.isPending) {
-      return;
+      return false;
     }
-    checkMutation.mutate();
+
+    return new Promise<boolean>((resolve) => {
+      checkMutation.mutate(undefined, {
+        onSuccess: () => resolve(true),
+        onError: () => resolve(false),
+      });
+    });
   };
 
   return { handleCheckAttendance };

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -26,18 +26,21 @@ export const useAppInitializer = ({
         window.location.pathname.startsWith("/onboarding");
       if (isOnboardingPage) return;
 
-      const modalShown =
-        await callbacksRef.current.onCheckAttendance();
+      try {
+        const modalShown =
+          await callbacksRef.current.onCheckAttendance();
 
-      if (modalShown) {
-        useAttendanceStore
-          .getState()
-          .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
-      } else {
         const store = useAttendanceStore.getState();
-        if (!store.onModalClosed) {
-          callbacksRef.current.onCheckGoalPopups();
+        if (modalShown) {
+          store.setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
+        } else {
+          if (!store.onModalClosed) {
+            callbacksRef.current.onCheckGoalPopups();
+          }
         }
+      } catch (error) {
+        console.error("출석 체크 실패:", error);
+        callbacksRef.current.onCheckGoalPopups();
       }
     };
 

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -34,7 +34,10 @@ export const useAppInitializer = ({
           .getState()
           .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
       } else {
-        callbacksRef.current.onCheckGoalPopups();
+        const store = useAttendanceStore.getState();
+        if (!store.onModalClosed) {
+          callbacksRef.current.onCheckGoalPopups();
+        }
       }
     };
 

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -18,6 +18,14 @@ export const useAppInitializer = ({
   const prevPathnameRef = useRef(window.location.pathname);
 
   useEffect(() => {
+    // 중복 호출 방지하며 목표 팝업 실행
+    const runGoalPopupsIfNeeded = () => {
+      const store = useAttendanceStore.getState();
+      if (!store.onModalClosed) {
+        callbacksRef.current.onCheckGoalPopups();
+      }
+    };
+
     const runChecks = async () => {
       const token = storage.getToken();
       if (!token) return;
@@ -30,17 +38,16 @@ export const useAppInitializer = ({
         const modalShown =
           await callbacksRef.current.onCheckAttendance();
 
-        const store = useAttendanceStore.getState();
         if (modalShown) {
-          store.setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
+          useAttendanceStore
+            .getState()
+            .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
         } else {
-          if (!store.onModalClosed) {
-            callbacksRef.current.onCheckGoalPopups();
-          }
+          runGoalPopupsIfNeeded();
         }
       } catch (error) {
         console.error("출석 체크 실패:", error);
-        callbacksRef.current.onCheckGoalPopups();
+        runGoalPopupsIfNeeded();
       }
     };
 

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from "react";
 import { storage } from "@/apis/storage";
 import router from "@/routes/router";
+import { useAttendanceStore } from "@/store/attendance/attendance";
 
 interface UseAppInitializerProps {
-  onCheckAttendance: () => void;
+  onCheckAttendance: () => Promise<boolean>;
   onCheckGoalPopups: () => void;
 }
 
@@ -17,7 +18,7 @@ export const useAppInitializer = ({
   const prevPathnameRef = useRef(window.location.pathname);
 
   useEffect(() => {
-    const runChecks = () => {
+    const runChecks = async () => {
       const token = storage.getToken();
       if (!token) return;
 
@@ -25,8 +26,16 @@ export const useAppInitializer = ({
         window.location.pathname.startsWith("/onboarding");
       if (isOnboardingPage) return;
 
-      callbacksRef.current.onCheckAttendance();
-      callbacksRef.current.onCheckGoalPopups();
+      const modalShown =
+        await callbacksRef.current.onCheckAttendance();
+
+      if (modalShown) {
+        useAttendanceStore
+          .getState()
+          .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
+      } else {
+        callbacksRef.current.onCheckGoalPopups();
+      }
     };
 
     runChecks();

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
 import AsyncBoundary from "@/components/AsyncBoundary";
+import { useBgmStore } from "@/store/bgm";
 import HomeContent from "./components/HomeContent";
 import useBgm from "./hooks/useBgm";
 
 const HomePage = () => {
-  const [bgmEnabled, setBgmEnabled] = useState(true);
+  const bgmEnabled = useBgmStore((s) => s.enabled);
+  const setBgmEnabled = useBgmStore((s) => s.setEnabled);
   useBgm("/audio/bgm.mp3", 0.3, bgmEnabled);
 
   return (

--- a/src/pages/home/components/HeaderButtons.tsx
+++ b/src/pages/home/components/HeaderButtons.tsx
@@ -53,7 +53,7 @@ const HeaderButtons = ({
           ref={boomerangRef}
           type="button"
           className="flex items-center justify-center rounded-lg border border-gray-300 bg-white p-11"
-          onClick={() => navigate("/mypage?tab=mission")}
+          onClick={() => navigate("/mypage?tab=mission&view=retry")}
         >
           <BoomerangIcon className="h-40 w-40" />
         </button>

--- a/src/pages/home/components/HomeModals.tsx
+++ b/src/pages/home/components/HomeModals.tsx
@@ -19,7 +19,10 @@ const HomeModals = () => {
     <AttendanceModal
       isOpen={showModal}
       onClose={handleClose}
-      onGoToCalendar={handleClose}
+      onGoToCalendar={() => {
+        handleClose();
+        window.location.href = "/mypage";
+      }}
       count={attendanceData.streak}
       attendance={getWeeklyAttendance(attendanceData.streak)}
     />

--- a/src/pages/home/components/HomeModals.tsx
+++ b/src/pages/home/components/HomeModals.tsx
@@ -1,9 +1,17 @@
+import { useNavigate } from "react-router-dom";
 import { useAttendanceStore } from "@/store/attendance/attendance";
 import { getWeeklyAttendance } from "@/utils/attendance/attendance";
 import AttendanceModal from "./modal/AttendanceModal";
 
 const HomeModals = () => {
-  const { showModal, setShowModal, attendanceData, onModalClosed, setOnModalClosed } = useAttendanceStore();
+  const navigate = useNavigate();
+  const {
+    showModal,
+    setShowModal,
+    attendanceData,
+    onModalClosed,
+    setOnModalClosed,
+  } = useAttendanceStore();
 
   const handleClose = () => {
     setShowModal(false);
@@ -21,7 +29,7 @@ const HomeModals = () => {
       onClose={handleClose}
       onGoToCalendar={() => {
         handleClose();
-        window.location.href = "/mypage";
+        navigate("/mypage");
       }}
       count={attendanceData.streak}
       attendance={getWeeklyAttendance(attendanceData.streak)}

--- a/src/pages/home/components/HomeModals.tsx
+++ b/src/pages/home/components/HomeModals.tsx
@@ -3,15 +3,23 @@ import { getWeeklyAttendance } from "@/utils/attendance/attendance";
 import AttendanceModal from "./modal/AttendanceModal";
 
 const HomeModals = () => {
-  const { showModal, setShowModal, attendanceData } = useAttendanceStore();
+  const { showModal, setShowModal, attendanceData, onModalClosed, setOnModalClosed } = useAttendanceStore();
+
+  const handleClose = () => {
+    setShowModal(false);
+    if (onModalClosed) {
+      onModalClosed();
+      setOnModalClosed(null);
+    }
+  };
 
   if (!attendanceData) return null;
 
   return (
     <AttendanceModal
       isOpen={showModal}
-      onClose={() => setShowModal(false)}
-      onGoToCalendar={() => setShowModal(false)}
+      onClose={handleClose}
+      onGoToCalendar={handleClose}
       count={attendanceData.streak}
       attendance={getWeeklyAttendance(attendanceData.streak)}
     />

--- a/src/pages/home/components/QuestionBox.tsx
+++ b/src/pages/home/components/QuestionBox.tsx
@@ -9,29 +9,32 @@ const QuestionBox = forwardRef<HTMLDivElement, QuestionBoxProps>(
   ({ nickname, onTimeSelect }, ref) => {
     return (
       <div ref={ref} className="w-325">
-      <div className="rounded-lg bg-white px-38 py-23">
-        <div className="flex flex-col items-center">
-          <span className="body-2 text-black">안녕하세요, {nickname}님 !</span>
-          <span className="body-2 text-black">
-            지금 딱 집중 가능한 시간을 알려주세요!
-          </span>
-        </div>
+        <div className="rounded-lg bg-white px-38 py-23">
+          <div className="flex flex-col items-center text-center">
+            <span className="body-2 text-black">
+              안녕하세요, {nickname}님 !
+            </span>
+            <span className="body-2 text-black">
+              지금 딱 집중 가능한 시간을 알려주세요!
+            </span>
+          </div>
 
-        <div className="mt-20 flex justify-center gap-24">
-          {[5, 10, 30].map((time) => (
-            <button
-              key={time}
-              type="button"
-              onClick={() => onTimeSelect(time)}
-              className="body-4 rounded-md bg-moamoa-50 px-17 py-8 text-moamoa-500"
-            >
-              {time}분
-            </button>
-          ))}
+          <div className="mt-20 flex justify-center gap-24">
+            {[5, 10, 30].map((time) => (
+              <button
+                key={time}
+                type="button"
+                onClick={() => onTimeSelect(time)}
+                className="body-4 rounded-md bg-moamoa-50 px-17 py-8 text-moamoa-500"
+              >
+                {time}분
+              </button>
+            ))}
+          </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 export default QuestionBox;

--- a/src/pages/mypage/components/missioncard/MissionList.tsx
+++ b/src/pages/mypage/components/missioncard/MissionList.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import IcSadSquirrel from "@/assets/icons/ic_sadsquirrel.svg?react";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import MissionCard from "@/components/MissionCard";
@@ -21,8 +21,13 @@ import type {
 } from "./missionList.types";
 
 export default function MissionTab() {
-  const [subTab, setSubTab] = useState<MissionSubTabKey>("liked");
-  const [doneView, setDoneView] = useState<"done" | "retry">("done");
+  const [searchParams] = useSearchParams();
+  const viewParam = searchParams.get("view");
+  const initialDoneView = viewParam === "retry" ? "retry" : "done";
+  const initialSubTab = viewParam === "retry" ? "done" : "liked";
+
+  const [subTab, setSubTab] = useState<MissionSubTabKey>(initialSubTab);
+  const [doneView, setDoneView] = useState<"done" | "retry">(initialDoneView);
   const [retryModalOpen, setRetryModalOpen] = useState(false);
   const [retryMissionId, setRetryMissionId] = useState<string | null>(null);
 

--- a/src/pages/mypage/components/missioncard/MissionList.tsx
+++ b/src/pages/mypage/components/missioncard/MissionList.tsx
@@ -21,13 +21,13 @@ import type {
 } from "./missionList.types";
 
 export default function MissionTab() {
-  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const viewParam = searchParams.get("view");
-  const initialDoneView = viewParam === "retry" ? "retry" : "done";
-  const initialSubTab = viewParam === "retry" ? "done" : "liked";
 
-  const [subTab, setSubTab] = useState<MissionSubTabKey>(initialSubTab);
-  const [doneView, setDoneView] = useState<"done" | "retry">(initialDoneView);
+  const subTab: MissionSubTabKey = viewParam === "retry" ? "done" : "liked";
+  const doneView: "done" | "retry" = viewParam === "retry" ? "retry" : "done";
+
   const [retryModalOpen, setRetryModalOpen] = useState(false);
   const [retryMissionId, setRetryMissionId] = useState<string | null>(null);
 
@@ -72,10 +72,20 @@ export default function MissionTab() {
         : "자세히 보기";
   const hideHeart = subTab !== "liked";
 
-  const navigate = useNavigate();
-
   const goDetail = (id: string) => {
     navigate(`/mission/${id}`);
+  };
+
+  const handleTabChange = (
+    nextSubTab: MissionSubTabKey,
+    nextDoneView: "done" | "retry"
+  ) => {
+    const params = { tab: "mission" as const };
+    if (nextSubTab === "done" && nextDoneView === "retry") {
+      setSearchParams({ ...params, view: "retry" });
+    } else {
+      setSearchParams(params);
+    }
   };
 
   return (
@@ -83,13 +93,10 @@ export default function MissionTab() {
       <MissionTabs
         subTab={subTab}
         doneView={doneView}
-        onSelect={(nextSubTab, nextDoneView) => {
-          setSubTab(nextSubTab);
-          setDoneView(nextDoneView);
-        }}
+        onSelect={handleTabChange}
       />
 
-      <div className="-mx-25 w-screen">
+      <div className="-mx-layout-side w-screen">
         <div
           className={[
             "relative flex w-full flex-col gap-6 rounded-t-xl pt-17 shadow-sm",
@@ -97,7 +104,7 @@ export default function MissionTab() {
             visibleMissions.length === 0 ? "bg-[#E6E6E6]" : "bg-white",
           ].join(" ")}
         >
-          <div className="flex w-full flex-col gap-4 px-25">
+          <div className="flex w-full flex-col gap-4 px-layout-side">
             <MissionFilters
               timeSort={timeSort}
               category={category}

--- a/src/pages/pocket/hooks/useQuery/usePocket.ts
+++ b/src/pages/pocket/hooks/useQuery/usePocket.ts
@@ -6,6 +6,5 @@ export const usePocket = () => {
     queryKey: ["pocket"],
     queryFn: getPocket,
     staleTime: 0,
-    gcTime: 0,
   });
 };

--- a/src/pages/pocket/hooks/useQuery/usePocket.ts
+++ b/src/pages/pocket/hooks/useQuery/usePocket.ts
@@ -5,5 +5,7 @@ export const usePocket = () => {
   return useSuspenseQuery({
     queryKey: ["pocket"],
     queryFn: getPocket,
+    staleTime: 0,
+    gcTime: 0,
   });
 };

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -37,7 +37,7 @@ export default function Search() {
           onRightIconClick={
             mode === "category"
               ? () => navigate("/search?mode=keyword")
-              : undefined
+              : () => navigate("/mypage?tab=mission")
           }
         />
       )}

--- a/src/pages/settings/AccountInfoPage.tsx
+++ b/src/pages/settings/AccountInfoPage.tsx
@@ -1,5 +1,6 @@
 ﻿import type { ReactNode } from "react";
 import { Component, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import AsyncBoundary from "@/components/AsyncBoundary";
 import Header from "@/components/common/header/Header";
 import { useApiError } from "@/hooks/api/useApiError";
@@ -43,6 +44,7 @@ class ErrorBoundary extends Component<
 }
 
 function AccountInfoPageInner() {
+  const navigate = useNavigate();
   const { data: profile } = useMyProfile();
   const { mutate, isPending } = useUpdateMyProfile();
 
@@ -74,9 +76,9 @@ function AccountInfoPageInner() {
   return (
     <div>
       <Header title="프로필 설정" property="common" />
-      <div className="-mx-25 mt-14 h-2 bg-gray-200" />
+      <div className="-mx-layout-side mt-14 h-2 bg-gray-200" />
 
-      <div className="flex min-h-dvh w-full flex-col overflow-y-auto">
+      <div className="flex min-h-dvh w-full flex-col">
         <div className="flex w-full flex-1 flex-col items-center pb-40">
           <AccountInfoHeader
             selectedId={draft.profileId}
@@ -100,7 +102,10 @@ function AccountInfoPageInner() {
 
       <AccountInfoSuccessModal
         open={isSuccessOpen}
-        onConfirm={() => setIsSuccessOpen(false)}
+        onConfirm={() => {
+          setIsSuccessOpen(false);
+          navigate("/settings");
+        }}
       />
     </div>
   );

--- a/src/pages/settings/PasswordChangePage.tsx
+++ b/src/pages/settings/PasswordChangePage.tsx
@@ -1,5 +1,6 @@
 ﻿import { useEffect, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import Header from "@/components/common/header/Header";
 import type { ApiError } from "@/types/api/api";
 import type { ChangePasswordRequest } from "@/types/password/password";
@@ -10,6 +11,7 @@ import PasswordChangeIntro from "./components/Password/PasswordChangeIntro";
 import PasswordChangeSuccessModal from "./components/Password/PasswordChangeSuccessModal";
 
 export default function PasswordChangePage() {
+  const navigate = useNavigate();
   const [successOpen, setSuccessOpen] = useState(false);
   const { mutate, isPending } = useChangePassword();
   const {
@@ -108,6 +110,7 @@ export default function PasswordChangePage() {
 
   const onConfirmSuccess = () => {
     setSuccessOpen(false);
+    navigate("/settings");
   };
 
   return (

--- a/src/pages/settings/components/Interests.tsx
+++ b/src/pages/settings/components/Interests.tsx
@@ -1,4 +1,5 @@
 ﻿import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Header from "@/components/common/header/Header";
 import BottomActionBar from "./common/BottomActionBar";
 import InterestCategoryCard from "./interests/InterestCategoryCard";
@@ -9,6 +10,7 @@ import { useSettingOnboarding, useUpdateSettingOnboarding } from "./interests/ho
 type SelectedMap = Record<number, number[]>;
 
 export default function InterestPage() {
+  const navigate = useNavigate();
   const { data: interests } = useSettingInterests();
   const { data: selectedFromServer } = useSettingOnboarding();
   const { mutate, isPending } = useUpdateSettingOnboarding();
@@ -100,7 +102,10 @@ export default function InterestPage() {
 
       <InterestsSuccessModal
         open={isSuccessOpen}
-        onConfirm={() => setIsSuccessOpen(false)}
+        onConfirm={() => {
+          setIsSuccessOpen(false);
+          navigate("/settings");
+        }}
       />
     </div>
   );

--- a/src/pages/settings/components/SettingsSectionList.tsx
+++ b/src/pages/settings/components/SettingsSectionList.tsx
@@ -56,9 +56,9 @@ export const sections: Section[] = [
     title: "서비스 편의 기능",
     wrapperClass:
       "flex min-h-174 w-full flex-col items-center gap-22 self-stretch",
-    innerClass: "flex min-h-147 w-full flex-col items-start gap-8",
+    innerClass: "flex min-h-150 w-full flex-col items-start gap-16",
     titleClass: "flex min-h-25 w-full items-center",
-    listClass: "flex w-full flex-col gap-8",
+    listClass: "flex w-full flex-col gap-3",
     buttonClass:
       "flex min-h-53 w-full items-center justify-between self-stretch py-12",
     items: [

--- a/src/pages/settings/components/TargetMissionCount.tsx
+++ b/src/pages/settings/components/TargetMissionCount.tsx
@@ -1,4 +1,5 @@
 ﻿import { useId, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import AsyncBoundary from "@/components/AsyncBoundary";
 import Header from "@/components/common/header/Header";
 import MoaToggle from "@/pages/settings/components/common/Moatoggle";
@@ -17,6 +18,7 @@ const DURATION_OPTIONS: DurationOption[] = [
 ];
 
 function TargetMissionCountInner() {
+  const navigate = useNavigate();
   const labelId = useId();
   const [isSuccessOpen, setIsSuccessOpen] = useState(false);
   const {
@@ -113,7 +115,10 @@ function TargetMissionCountInner() {
 
       <InterestsSuccessModal
         open={isSuccessOpen}
-        onConfirm={() => setIsSuccessOpen(false)}
+        onConfirm={() => {
+          setIsSuccessOpen(false);
+          navigate("/settings");
+        }}
         title="목표 설정 변경 완료!"
         description={
           <>

--- a/src/pages/settings/components/account/PhoneField.tsx
+++ b/src/pages/settings/components/account/PhoneField.tsx
@@ -29,13 +29,13 @@ export default function PhoneField({
         <input
           value={value}
           disabled
-          className="h-46 flex-1 rounded-lg bg-gray-100 px-15 py-8 text-black outline-none"
+          className="h-46 min-w-0 flex-1 rounded-lg bg-gray-100 px-15 py-8 text-black outline-none"
         />
 
         <Button
           type="button"
           onClick={onStartEdit}
-          className="flex h-46 w-78 items-center justify-center rounded-lg bg-moamoa-50 px-15 py-8"
+          className="flex h-46 items-center justify-center rounded-lg bg-moamoa-50 px-15 py-8"
         >
           <span className="body-2 whitespace-nowrap text-moamoa-400">변경</span>
         </Button>
@@ -49,14 +49,14 @@ export default function PhoneField({
         <input
           value={newValue}
           onChange={(e) => onChangeNewValue(e.target.value)}
-          className="h-46 flex-1 rounded-lg bg-gray-100 px-15 py-8 text-black outline-none"
+          className="h-46 min-w-0 flex-1 rounded-lg bg-gray-100 px-15 py-8 text-black outline-none"
           placeholder="-구분없이 입력"
         />
 
         <Button
           type="button"
           onClick={onRequestVerification}
-          className="bgr-moamoa-50 flex h-46 w-78 items-center justify-center rounded-lg px-15 py-8"
+          className="flex h-46 items-center justify-center rounded-lg bg-moamoa-50 px-15 py-8"
         >
           <span className="body-2 whitespace-nowrap text-moamoa-400">
             인증번호
@@ -68,14 +68,14 @@ export default function PhoneField({
         <input
           value={verifyCode}
           onChange={(e) => onChangeVerifyCode(e.target.value)}
-          className="h-46 flex-1 rounded-lg bg-gray-100 px-15 py-8 text-black outline-none"
+          className="h-46 min-w-0 flex-1 rounded-lg bg-gray-100 px-15 py-8 text-black outline-none"
           placeholder="인증번호 입력"
         />
 
         <Button
           type="button"
           onClick={onConfirm}
-          className="flex h-46 w-78 items-center justify-center rounded-lg bg-moamoa-50 px-15 py-8"
+          className="flex h-46 items-center justify-center rounded-lg bg-moamoa-50 px-15 py-8"
         >
           <span className="body-2 whitespace-nowrap text-moamoa-400">확인</span>
         </Button>

--- a/src/pages/settings/components/faq/FaqSectionList.tsx
+++ b/src/pages/settings/components/faq/FaqSectionList.tsx
@@ -42,17 +42,17 @@ export default function FaqSectionList() {
                         : "py-8 pr-18 pl-16",
                     ].join(" ")}
                   >
-                    <div className="flex w-full items-start gap-5">
-                      <span className="body-2 h-21 w-15 text-black">Q.</span>
-                      <span className="body-2 flex-1 text-black">
+                    <button
+                      type="button"
+                      onClick={() => setOpenIndex(isOpen ? null : itemKey)}
+                      className="flex w-full items-start gap-5"
+                      aria-expanded={isOpen}
+                    >
+                      <span className="body-2 h-21 w-15 text-left text-black">Q.</span>
+                      <span className="body-2 flex-1 text-left text-black">
                         {item.question}
                       </span>
-                      <button
-                        type="button"
-                        onClick={() => setOpenIndex(isOpen ? null : itemKey)}
-                        className="flex h-24 w-24 items-center justify-center self-start"
-                        aria-label={isOpen ? "닫기" : "펼치기"}
-                      >
+                      <span className="flex h-24 w-24 shrink-0 items-center justify-center self-start">
                         <IcLeft
                           className={[
                             "h-16 w-16 text-gray-700",
@@ -60,8 +60,8 @@ export default function FaqSectionList() {
                           ].join(" ")}
                           aria-hidden
                         />
-                      </button>
-                    </div>
+                      </span>
+                    </button>
 
                     {isOpen && (
                       <div

--- a/src/pages/settings/components/inquiry/InquiryPage.tsx
+++ b/src/pages/settings/components/inquiry/InquiryPage.tsx
@@ -102,16 +102,8 @@ export default function InquiryPage() {
                 images: draft.images,
               },
               {
-                onSuccess: (result) => {
-                  // ✅ 성공 후 행동 택1
-                  // 1) 상세로 이동
-                  navigate(`/settings/inquiry/${result.inquiryId}`);
-
-                  // 2) 또는 탭을 list로 전환
-                  // setTab("list");
-
-                  // (선택) 폼 초기화
-                  // setDraft({ category: null, title: "", content: "", images: [] });
+                onSuccess: () => {
+                  navigate("/settings");
                 },
               }
             );

--- a/src/store/attendance/attendance.ts
+++ b/src/store/attendance/attendance.ts
@@ -8,13 +8,17 @@ export interface AttendanceData {
 interface AttendanceStore {
   showModal: boolean;
   attendanceData: AttendanceData | null;
+  onModalClosed: (() => void) | null;
   setShowModal: (show: boolean) => void;
   setAttendanceData: (data: AttendanceData) => void;
+  setOnModalClosed: (callback: (() => void) | null) => void;
 }
 
 export const useAttendanceStore = create<AttendanceStore>((set) => ({
   showModal: false,
   attendanceData: null,
+  onModalClosed: null,
   setShowModal: (show) => set({ showModal: show }),
   setAttendanceData: (data) => set({ attendanceData: data }),
+  setOnModalClosed: (callback) => set({ onModalClosed: callback }),
 }));

--- a/src/store/bgm.ts
+++ b/src/store/bgm.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface BgmStore {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+}
+
+export const useBgmStore = create<BgmStore>((set) => ({
+  enabled: true,
+  setEnabled: (enabled) => set({ enabled }),
+}));


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->


## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
#### 주머니 (Pocket)
  - 주머니 정보가 바로 반영되도록 staleTime 설정 추가
  - 주머니 캘린더 보러가기 버튼을 마이페이지로 이동하도록 수정
#### 모달 & 팝업
  - 출석 모달과 실패 팝업이 순차적으로 표시되도록 개선
    - 출석 모달이 먼저 표시되고, 닫힌 후 실패 팝업 표시
    - `useAttendanceStore`에 `onModalClosed` 콜백 추가
  - 설정 완료 모달 닫기 시 설정 페이지로 이동하도록 수정

  #### 배경음악 (BGM)
  - 페이지 이동 시에도 배경음악 토글 상태가 유지되도록 개선
    - Zustand store(`useBgmStore`)로 상태 관리

  #### 설정 페이지
  - 탐색 화면 하트 아이콘 → 내 미션으로 이동
  - 서비스 편의기능 섹션 gap 통일
  - FAQ 전체 아이템 클릭 가능하도록 개선
  - PhoneField 고정 너비 제거 및 `min-w-0` 적용

  ### 🎨 Design
  - 홈 화면 질문 박스 중앙 정렬

  ### 🛠 Chore
  - 앱 이름 "모아모아" → "모아" 변경
    - manifest.json 업데이트


 ##  테스트 체크리스트
  - [ ] 주머니에서 도토리 사용 후 포인트가 즉시 반영되는지 확인
  - [ ] 출석 모달과 실패 팝업이 순차적으로 표시되는지 확인
  - [ ] 페이지 이동 후 배경음악 상태가 유지되는지 확인
  - [ ] 설정 페이지 UI 개선 사항 확인
  - [ ] FAQ 전체 영역 클릭 가능 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 배경음악 설정 저장 및 토글 기능 추가
  * 출석 모달 종료 시 실행되는 콜백 등록/해제 기능 추가

* **Refactor**
  * 출석 확인 흐름을 비동기화해 성공 여부를 반환하고 처리 분기 개선
  * 홈 화면 상태 관리를 전역 저장소 기반으로 전환

* **Bug Fixes / UX**
  * 검색 우측 아이콘에 탭 이동 동작 추가
  * 미션 목록 초기 탭을 URL 파라미터로 제어
  * 여러 설정 화면에서 처리 후 설정 목록으로 이동하도록 네비게이션 개선

* **Chores**
  * 앱 표시명을 "모아모아"로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->