### PR TITLE
Fix: 바텀 네비게이션 바 하단 safearea 제거

### DIFF
--- a/src/components/common/navbar/BottomNavbar.tsx
+++ b/src/components/common/navbar/BottomNavbar.tsx
@@ -60,7 +60,7 @@ function NavItem({ to, label, Icon }: NavItemProps) {
 export default function BottomNavigation() {
   return (
     <nav
-      className="fixed right-0 bottom-0 left-0 z-20 mx-auto w-full bg-white pb-safe-bottom"
+      className="fixed right-0 bottom-0 left-0 z-20 mx-auto w-full bg-white"
       style={{
         boxShadow: "0px -8px 50px 3px rgba(0, 0, 0, 0.1)",
       }}


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #1

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 바텀 네비게이션 바 하단 safearea 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 하단 네비게이션 바의 수직 간격을 조정했습니다. 특히 동적 아일랜드나 노치가 있는 기기에서 하단 여백이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->