### PR TITLE
Feat: 성과 -> 다시풀기 이동 로직 추가

### DIFF
--- a/src/pages/mypage/components/AcornHistory.tsx
+++ b/src/pages/mypage/components/AcornHistory.tsx
@@ -63,7 +63,7 @@ export default function AcornHistory() {
       tab: toApiTab(filter),
       sort: toApiSort(sortKey),
       period: toApiPeriod(sortKey),
-      earnSource: filter === "progress" ? toApiEarnSource(earnSource) : "ALL",
+      earnSource: filter === "progress" ? toApiEarnSource(earnSource) : undefined,
     });
 
   const { ref } = useInfiniteScroll({

--- a/src/pages/mypage/components/PerformanceMissionList.tsx
+++ b/src/pages/mypage/components/PerformanceMissionList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import IcAcorn from "@/assets/icons/ic_acorn.svg?react";
 import IcAttendance from "@/assets/icons/ic_attendance.svg?react";
@@ -54,13 +55,16 @@ export default function PerformanceMissionList({
 }) {
   const navigate = useNavigate();
   const { handleError } = useApiError();
+  const [isNavigating, setIsNavigating] = useState(false);
 
   const handleOpenMission = async (row: PerformanceMissionRow) => {
+    if (isNavigating) return;
     if (row.missionId == null || !Number.isFinite(row.missionId)) {
       return;
     }
 
     try {
+      setIsNavigating(true);
       let page = 0;
       let hasNext = true;
       let isRetry = false;
@@ -89,7 +93,8 @@ export default function PerformanceMissionList({
       }
     } catch (error) {
       handleError(error);
-      navigate(`/mypage/mission/${row.missionId}`);
+    } finally {
+      setIsNavigating(false);
     }
   };
 
@@ -145,6 +150,7 @@ export default function PerformanceMissionList({
                       onClick={() => handleOpenMission(row)}
                       className="justify-self-end"
                       aria-label="View mission detail"
+                      disabled={isNavigating}
                     >
                       <IcDropdown
                         className="h-24 w-24 -rotate-90 text-gray-700"

--- a/src/pages/mypage/components/PerformanceMissionList.tsx
+++ b/src/pages/mypage/components/PerformanceMissionList.tsx
@@ -4,6 +4,8 @@ import IcAttendance from "@/assets/icons/ic_attendance.svg?react";
 import IcDropdown from "@/assets/icons/ic_dropdown.svg?react";
 import IcMinus from "@/assets/icons/ic_minus.svg?react";
 import IcPlus from "@/assets/icons/ic_plus.svg?react";
+import { getMyMissions } from "@/apis/missions/myMissions";
+import { useApiError } from "@/hooks/api/useApiError";
 
 type RowKind =
   | "attendance"
@@ -51,6 +53,45 @@ export default function PerformanceMissionList({
   rows: PerformanceMissionRow[];
 }) {
   const navigate = useNavigate();
+  const { handleError } = useApiError();
+
+  const handleOpenMission = async (row: PerformanceMissionRow) => {
+    if (row.missionId == null || !Number.isFinite(row.missionId)) {
+      return;
+    }
+
+    try {
+      let page = 0;
+      let hasNext = true;
+      let isRetry = false;
+      let guard = 0;
+
+      while (hasNext && guard < 20) {
+        const retryList = await getMyMissions({
+          status: "RETRY",
+          condition: "LATEST",
+          page,
+          size: 50,
+        });
+        isRetry = retryList.missions.some(
+          (mission) => mission.missionId === row.missionId
+        );
+        if (isRetry) break;
+        hasNext = retryList.hasNext;
+        page += 1;
+        guard += 1;
+      }
+
+      if (isRetry) {
+        navigate(`/mission/${row.missionId}`);
+      } else {
+        navigate(`/mypage/mission/${row.missionId}`);
+      }
+    } catch (error) {
+      handleError(error);
+      navigate(`/mypage/mission/${row.missionId}`);
+    }
+  };
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -101,14 +142,7 @@ export default function PerformanceMissionList({
 
                     <button
                       type="button"
-                      onClick={() => {
-                        if (
-                          row.missionId != null &&
-                          Number.isFinite(row.missionId)
-                        ) {
-                          navigate(`/mypage/mission/${row.missionId}`);
-                        }
-                      }}
+                      onClick={() => handleOpenMission(row)}
                       className="justify-self-end"
                       aria-label="View mission detail"
                     >

--- a/src/pages/mypage/components/PerformanceSection.tsx
+++ b/src/pages/mypage/components/PerformanceSection.tsx
@@ -17,14 +17,14 @@ export default function PerformanceSection({
           ? parsedMissionId
           : undefined;
 
-      return ({
-      rowId: `${item.id}-${mission.id}`,
-      missionId,
-      kind: mission.kind,
-      title: mission.title,
-      acornDelta: mission.acornDelta,
-      durationMin: mission.kind === "mission" ? item.durationMin : null,
-    });
+      return {
+        rowId: `${item.id}-${mission.id}`,
+        missionId,
+        kind: mission.kind,
+        title: mission.title,
+        acornDelta: mission.acornDelta,
+        durationMin: mission.kind === "mission" ? item.durationMin : null,
+      };
     })
   );
 
@@ -48,7 +48,7 @@ export default function PerformanceSection({
           <div className="heading-3 flex h-28 w-full min-w-[273px] items-center px-[24.5px]">
             <span className="h-28 w-45">Total</span>
             <span className="min-w-[70px] flex-1" aria-hidden />
-            <span className="h-28 w-40">{totalMin}분</span>
+            <span className="h-28 w-40 whitespace-nowrap">{totalMin}분</span>
             <span className="min-w-[70px] flex-1" aria-hidden />
             <span className="flex h-28 w-48 items-center justify-center">
               <span className="mr-4 flex h-20 items-center text-center">

--- a/src/pages/mypage/components/missioncard/MissionList.tsx
+++ b/src/pages/mypage/components/missioncard/MissionList.tsx
@@ -25,7 +25,8 @@ export default function MissionTab() {
   const [searchParams, setSearchParams] = useSearchParams();
   const viewParam = searchParams.get("view");
 
-  const subTab: MissionSubTabKey = viewParam === "retry" ? "done" : "liked";
+  const subTab: MissionSubTabKey =
+    viewParam === "retry" || viewParam === "done" ? "done" : "liked";
   const doneView: "done" | "retry" = viewParam === "retry" ? "retry" : "done";
 
   const [retryModalOpen, setRetryModalOpen] = useState(false);
@@ -83,9 +84,13 @@ export default function MissionTab() {
     const params = { tab: "mission" as const };
     if (nextSubTab === "done" && nextDoneView === "retry") {
       setSearchParams({ ...params, view: "retry" });
-    } else {
-      setSearchParams(params);
+      return;
     }
+    if (nextSubTab === "done") {
+      setSearchParams({ ...params, view: "done" });
+      return;
+    }
+    setSearchParams(params);
   };
 
   return (

--- a/src/pages/mypage/hooks/useMyWalletBalance.ts
+++ b/src/pages/mypage/hooks/useMyWalletBalance.ts
@@ -5,5 +5,6 @@ export const useMyWalletBalance = () => {
   return useSuspenseQuery({
     queryKey: ["wallet", "me", "balance"],
     queryFn: getMyWalletBalance,
+    staleTime: 0,
   });
 };

--- a/src/pages/mypage/hooks/useMyWalletHistory.ts
+++ b/src/pages/mypage/hooks/useMyWalletHistory.ts
@@ -13,19 +13,27 @@ interface UseMyWalletHistoryParams {
   tab: WalletHistoryTab;
   sort: WalletHistorySort;
   period: WalletHistoryPeriod;
-  earnSource: WalletHistoryEarnSource;
+  earnSource?: WalletHistoryEarnSource;
 }
 
 export const useMyWalletHistory = (params: UseMyWalletHistoryParams) => {
   return useSuspenseInfiniteQuery({
     queryKey: ["wallet", "me", "history", params],
     initialPageParam: 1,
-    queryFn: ({ pageParam }) =>
-      getMyWalletHistory({
-        ...params,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    queryFn: ({ pageParam }) => {
+      const requestParams = {
+        tab: params.tab,
+        sort: params.sort,
+        period: params.period,
         page: pageParam,
         size: PAGE_SIZE,
-      }),
+        ...(params.earnSource ? { earnSource: params.earnSource } : {}),
+      };
+      return getMyWalletHistory(requestParams);
+    },
     getNextPageParam: (lastPage, _pages, lastPageParam) => {
       if (!lastPage.hasNext) return undefined;
       return lastPageParam + 1;

--- a/src/pages/settings/components/interests/InterestCategoryCard.tsx
+++ b/src/pages/settings/components/interests/InterestCategoryCard.tsx
@@ -48,7 +48,6 @@ export default function InterestCategoryCard({
     (row) => row.length > 0
   );
   const selectedCount = selected[category.id]?.length ?? 0;
-  const isActive = selectedCount > 0;
 
   return (
     <div

--- a/src/pages/settings/components/interests/InterestCategoryCard.tsx
+++ b/src/pages/settings/components/interests/InterestCategoryCard.tsx
@@ -54,7 +54,7 @@ export default function InterestCategoryCard({
     <div
       className={[
         "flex w-full flex-col items-start rounded-xl border-2 bg-white",
-        isActive ? "border-moamoa-300" : "border-black",
+        isOpen ? "border-moamoa-100" : "border-gray-300",
       ].join(" ")}
     >
       <button

--- a/src/types/wallet/walletHistory.ts
+++ b/src/types/wallet/walletHistory.ts
@@ -7,7 +7,7 @@ export interface WalletHistoryParams {
   tab: WalletHistoryTab;
   sort: WalletHistorySort;
   period: WalletHistoryPeriod;
-  earnSource: WalletHistoryEarnSource;
+  earnSource?: WalletHistoryEarnSource;
   page: number;
   size: number;
 }


### PR DESCRIPTION

## 🚀 관련 이슈

- close #200 

## 🔑 작업 내용

성과에서 다시풀기 이동 로직 추가했습니다!
도토리 히스토리 최신화 되게 했습니다!
설정 관심사 부분 테두리 색상 변경했습니다!

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 미션 행 네비게이션 흐름 개선 및 오류 처리 강화, 중복 네비게이션 방지

* **UI 개선**
  * 최소 시간 텍스트 줄바꿈 방지
  * 관심사 카테고리 카드 테두리 스타일 조정

* **기능 개선**
  * 탭 전환 동작 명확화(뷰 매핑 수정)
  * 지갑 잔액/내역 조회의 캐시·리패치 동작 조정(즉시 만료·항상 재요청)

* **타입 변경**
  * 지갑 내역 요청의 earnSource 파라미터를 선택형으로 변경 및 관련 요청 페이로드 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->