### PR TITLE
Refactor: 탐색화면 카테고리뷰 서브 카테고리 이동 시 화면도 함께 이동

### DIFF
--- a/src/apis/missions/recommendedMissions.ts
+++ b/src/apis/missions/recommendedMissions.ts
@@ -15,7 +15,6 @@ export const getRecommendedMissions = async (
     "/missions/recommend",
     { params }
   );
-  ``;
 
   if (!data.isSuccess) {
     throw new Error(data.message);

--- a/src/apis/missions/recommendedMissions.ts
+++ b/src/apis/missions/recommendedMissions.ts
@@ -2,13 +2,20 @@ import { authAPI } from "@/apis/axios";
 import type { ApiResponse } from "@/types/api/api";
 import type { MissionApiResponse } from "@/types/mission/mission";
 
-export const getRecommendedMissions = async (time: number | null) => {
+export const getRecommendedMissions = async (
+  time: number | null,
+  isRefresh: boolean = false
+) => {
+  const params: Record<string, unknown> = { isRefresh };
+  if (time !== null) {
+    params.time = time;
+  }
+
   const { data } = await authAPI.get<ApiResponse<MissionApiResponse[]>>(
     "/missions/recommend",
-    {
-      params: time !== null ? { time } : undefined,
-    }
+    { params }
   );
+  ``;
 
   if (!data.isSuccess) {
     throw new Error(data.message);

--- a/src/pages/onboarding/OnboardingRecommend.tsx
+++ b/src/pages/onboarding/OnboardingRecommend.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import IcCircleLeftArrow from "@/assets/icons/ic_circle_left_arrow.svg?react";
 import IcReload from "@/assets/icons/ic_reload.svg?react";
@@ -19,8 +20,12 @@ export default function OnboardingRecommend() {
 
 function OnboardingRecommendContent() {
   const navigate = useNavigate();
+  const [isRefresh, setIsRefresh] = useState(false);
 
-  const { data: missions, refetch } = useRecommendedMissions({ time: null });
+  const { data: missions, refetch } = useRecommendedMissions({
+    time: null,
+    isRefresh,
+  });
   const { activeIndex, dragX, isDragging, bind } = useCarouselDrag({
     totalItems: missions.length,
   });
@@ -90,7 +95,13 @@ function OnboardingRecommendContent() {
         <button
           type="button"
           className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 cursor-pointer items-center gap-6 rounded-2xl bg-moamoa-50 px-16 py-8"
-          onClick={() => refetch()}
+          onClick={() => {
+            if (isRefresh) {
+              refetch();
+            } else {
+              setIsRefresh(true);
+            }
+          }}
         >
           <IcReload className="size-19 text-moamoa-400" />
           <span className="body-2 text-moamoa-600">새로고침</span>

--- a/src/pages/search/components/TodayMissionSection.tsx
+++ b/src/pages/search/components/TodayMissionSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import IcReload from "@/assets/icons/ic_reload.svg?react";
 import { useScrapMission } from "@/hooks/useScrapMission";
 import { cn } from "@/utils/cn/cn";
@@ -5,7 +6,11 @@ import { useRecommendedMissions } from "../hooks/useQuery/useRecommendedMissions
 import RecommendedMissionCard from "./common/RecommendedMissionCard";
 
 export default function TodayMissionSection() {
-  const { data: missions, refetch } = useRecommendedMissions({ time: null });
+  const [isRefresh, setIsRefresh] = useState(false);
+  const { data: missions, refetch } = useRecommendedMissions({
+    time: null,
+    isRefresh,
+  });
   const scrapMutation = useScrapMission();
   return (
     <div className="mt-48">
@@ -14,7 +19,13 @@ export default function TodayMissionSection() {
         <button
           type="button"
           className="flex cursor-pointer items-center gap-6"
-          onClick={() => refetch()}
+          onClick={() => {
+            if (isRefresh) {
+              refetch();
+            } else {
+              setIsRefresh(true);
+            }
+          }}
         >
           <IcReload className="size-19 text-moamoa-400" />
           <span className="body-2 text-black">새로고침</span>

--- a/src/pages/search/hooks/useQuery/useRecommendedMissions.ts
+++ b/src/pages/search/hooks/useQuery/useRecommendedMissions.ts
@@ -3,13 +3,15 @@ import { getRecommendedMissions } from "@/apis/missions/recommendedMissions";
 
 interface UseRecommendedMissionsParams {
   time?: number | null;
+  isRefresh?: boolean;
 }
 
 export const useRecommendedMissions = ({
   time = null,
+  isRefresh = false,
 }: UseRecommendedMissionsParams = {}) => {
   return useSuspenseQuery({
-    queryKey: ["missions", "recommended", { time }],
-    queryFn: () => getRecommendedMissions(time),
+    queryKey: ["missions", "recommended", { time, isRefresh }],
+    queryFn: () => getRecommendedMissions(time, isRefresh),
   });
 };

--- a/src/pages/search/views/CategoryDetailView.tsx
+++ b/src/pages/search/views/CategoryDetailView.tsx
@@ -34,7 +34,7 @@ export default function CategoryDetailView() {
 
       <div className="-mx-layout-side mt-1 h-2 bg-gray-200" />
 
-      <div className="-mx-layout-side mt-18 overflow-x-auto">
+      <div key={selectedCategory} className="-mx-layout-side mt-18 overflow-x-auto">
         <div className="flex min-w-full gap-10 px-layout-side">
           {subCategories.map((sub) => (
             <SubCategoryButton

--- a/src/pages/today-mission/TodayMissionListView.tsx
+++ b/src/pages/today-mission/TodayMissionListView.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import IcLeft from "@/assets/icons/ic_left.svg?react";
 import IcReload from "@/assets/icons/ic_reload.svg?react";
@@ -12,11 +13,20 @@ export default function TodayMissionListView() {
   const [searchParams] = useSearchParams();
   const time = searchParams.get("time");
   const timeValue = time ? Number(time) : null;
+  const [isRefresh, setIsRefresh] = useState(false);
 
   const handleRefresh = () => {
-    queryClient.invalidateQueries({
-      queryKey: ["missions", "recommended", { time: timeValue }],
-    });
+    if (isRefresh) {
+      queryClient.invalidateQueries({
+        queryKey: [
+          "missions",
+          "recommended",
+          { time: timeValue, isRefresh: true },
+        ],
+      });
+    } else {
+      setIsRefresh(true);
+    }
   };
 
   return (
@@ -44,7 +54,7 @@ export default function TodayMissionListView() {
       </div>
 
       <AsyncBoundary>
-        <TodayMissionList />
+        <TodayMissionList isRefresh={isRefresh} />
       </AsyncBoundary>
     </div>
   );

--- a/src/pages/today-mission/components/TodayMissionList.tsx
+++ b/src/pages/today-mission/components/TodayMissionList.tsx
@@ -6,12 +6,21 @@ import { useRecommendedMissions } from "@/pages/search/hooks/useQuery/useRecomme
 
 const ITEMS_PER_PAGE = 10;
 
-export default function TodayMissionList() {
+interface TodayMissionListProps {
+  isRefresh?: boolean;
+}
+
+export default function TodayMissionList({
+  isRefresh = false,
+}: TodayMissionListProps) {
   const [searchParams] = useSearchParams();
   const time = searchParams.get("time");
   const timeValue = time ? Number(time) : null;
 
-  const { data: missions } = useRecommendedMissions({ time: timeValue });
+  const { data: missions } = useRecommendedMissions({
+    time: timeValue,
+    isRefresh,
+  });
   const scrapMutation = useScrapMission();
 
   const [displayedCount, setDisplayedCount] = useState(ITEMS_PER_PAGE);


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #206 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 탐색화면 카테고리뷰 서브 카테고리 이동 시 화면도 함께 이동하도록 수정

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|카테고리 이동|
|---|
|![bandicam 2026-02-14 01-36-12-513](https://github.com/user-attachments/assets/dac2b4ae-00b4-4dce-a72c-1baee8bce84a)|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 추천 미션 새로고침 기능의 동작을 개선했습니다. 새로고침 버튼의 첫 번째 클릭과 이후 클릭의 동작이 구분되어 더 나은 사용자 경험을 제공합니다.
  * 카테고리 변경 시 관련 상태가 자동으로 초기화되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->