### PR TITLE
Fix: 재도전 로직, UI 수정 및 크롬 영상 시청 완료 후 빈 탭 안열리게 수정

### DIFF
--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -107,6 +107,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      startWatchTimer(mission.videoLength * 1000);
       return;
     }
 

--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -56,7 +56,6 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
   );
   const watchTimeoutRef = useRef<number | null>(null);
   const clickedAtRef = useRef<number | null>(null);
-  const popupRef = useRef<Window | null>(null);
 
   const watchMission = useWatchMission();
   const changeMissionStatus = useChangeMissionStatus();
@@ -77,79 +76,77 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
     });
   };
 
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+  const clearMissionSession = () => {
+    sessionStorage.removeItem("missionClickedAt");
+    sessionStorage.removeItem("missionReturnUrl");
+  };
+
+  const startWatchTimer = (duration: number) => {
+    watchTimeoutRef.current = window.setTimeout(() => {
+      callWatchApi();
+      clearMissionSession();
+    }, duration);
+  };
+
   const handleContentClick = () => {
     if (isContentWatched) return;
     if (watchTimeoutRef.current) window.clearTimeout(watchTimeoutRef.current);
 
     const now = Date.now();
-    const watchDuration = mission.videoLength * 1000;
     clickedAtRef.current = now;
-
     sessionStorage.setItem("missionReturnUrl", `/mission/${missionId}`);
     sessionStorage.setItem("missionClickedAt", String(now));
 
-    popupRef.current = window.open(mission.videoUrl, "_blank");
+    if (isMobile) {
+      const link = document.createElement("a");
+      link.href = mission.videoUrl;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      return;
+    }
 
-    if (!popupRef.current) {
-      // 팝업이 차단된 경우: 타이머를 시작하지 않고 사용자에게 안내
-      sessionStorage.removeItem("missionClickedAt");
-      sessionStorage.removeItem("missionReturnUrl");
+    if (!window.open(mission.videoUrl, "_blank")) {
+      clearMissionSession();
       clickedAtRef.current = null;
       setErrorMessage("팝업이 차단되었습니다. 팝업 허용 후 다시 시도해주세요.");
       return;
     }
-    watchTimeoutRef.current = window.setTimeout(() => {
-      callWatchApi();
-      sessionStorage.removeItem("missionClickedAt");
-      sessionStorage.removeItem("missionReturnUrl");
-    }, watchDuration);
+
+    startWatchTimer(mission.videoLength * 1000);
   };
 
   useEffect(() => {
-    if (!isContentWatched) {
-      const savedClickedAt = sessionStorage.getItem("missionClickedAt");
-      if (savedClickedAt) {
-        const elapsed = Date.now() - Number(savedClickedAt);
-        const watchDuration = mission.videoLength * 1000;
-        if (elapsed >= watchDuration) {
-          sessionStorage.removeItem("missionClickedAt");
-          sessionStorage.removeItem("missionReturnUrl");
-          callWatchApi();
-        } else {
-          clickedAtRef.current = Number(savedClickedAt);
-          watchTimeoutRef.current = window.setTimeout(() => {
-            callWatchApi();
-            sessionStorage.removeItem("missionClickedAt");
-            sessionStorage.removeItem("missionReturnUrl");
-          }, watchDuration - elapsed);
-        }
-      }
+    if (isContentWatched) return;
+
+    const savedClickedAt = sessionStorage.getItem("missionClickedAt");
+    if (!savedClickedAt) return;
+
+    const elapsed = Date.now() - Number(savedClickedAt);
+    const watchDuration = mission.videoLength * 1000;
+
+    if (elapsed >= watchDuration) {
+      clearMissionSession();
+      callWatchApi();
+    } else {
+      clickedAtRef.current = Number(savedClickedAt);
+      startWatchTimer(watchDuration - elapsed);
     }
   }, []);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        const isMobileChrome =
-          (/Android/i.test(navigator.userAgent) &&
-            /Chrome/i.test(navigator.userAgent)) ||
-          (/iPhone|iPad/i.test(navigator.userAgent) &&
-            /CriOS/i.test(navigator.userAgent));
-        if (isMobileChrome && popupRef.current && !popupRef.current.closed) {
-          try {
-            popupRef.current.close();
-          } catch {}
-          popupRef.current = null;
-        }
+      if (document.visibilityState !== "visible") return;
 
-        if (clickedAtRef.current && !isContentWatched) {
-          const elapsed = Date.now() - clickedAtRef.current;
-          const watchDuration = mission.videoLength * 1000;
-          if (elapsed >= watchDuration) {
-            callWatchApi();
-            sessionStorage.removeItem("missionClickedAt");
-            sessionStorage.removeItem("missionReturnUrl");
-          }
+      if (clickedAtRef.current && !isContentWatched) {
+        const elapsed = Date.now() - clickedAtRef.current;
+        if (elapsed >= mission.videoLength * 1000) {
+          callWatchApi();
+          clearMissionSession();
         }
       }
     };

--- a/src/pages/mission/entry/MissionEntry.tsx
+++ b/src/pages/mission/entry/MissionEntry.tsx
@@ -67,6 +67,7 @@ function MissionEntryContent({ missionId }: { missionId: number }) {
   };
 
   const callWatchApi = () => {
+    if (isContentWatched) return;
     watchMission.mutate(missionId, {
       onSuccess: (data) => {
         setIsContentWatched(data.isContentWatched);

--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -102,6 +102,20 @@ function QuizPageContent({ missionId }: { missionId: number }) {
 
   const currentQuestion = mission.quizzes[currentQuestionIndex];
   const isLastQuestion = currentQuestionIndex === mission.quizzes.length - 1;
+  const isPreviouslyCorrect =
+    isRetry && currentQuestion.previousCorrectAnswer != null;
+
+  const getPreviousCorrectDisplayValue = () => {
+    const prev = currentQuestion.previousCorrectAnswer;
+    if (!prev) return null;
+    if (currentQuestion.type === "MULTIPLE") {
+      const idx = Number(prev);
+      if (!Number.isNaN(idx) && currentQuestion.option[idx - 1]) {
+        return currentQuestion.option[idx - 1];
+      }
+    }
+    return prev;
+  };
 
   const handleSubmit = () => {
     if (!currentQuestion) return;
@@ -151,6 +165,58 @@ function QuizPageContent({ missionId }: { missionId: number }) {
       setIsAnimating(false);
       feedbackTimeoutRef.current = null;
     }, totalDelay);
+  };
+
+  const handleRetryCorrectSkip = () => {
+    if (submitQuiz.isPending) return;
+
+    let userAnswer = currentQuestion.previousCorrectAnswer!;
+    if (currentQuestion.type === "MULTIPLE") {
+      const idx = Number(userAnswer);
+      if (!Number.isNaN(idx) && currentQuestion.option[idx - 1]) {
+        userAnswer = currentQuestion.option[idx - 1];
+      }
+    }
+
+    const newAnswers = [
+      ...answers,
+      { quizId: currentQuestion.quizId, userAnswer, isCorrect: true },
+    ];
+    setAnswers(newAnswers);
+    setCompletedQuestions(completedQuestions + 1);
+
+    if (isLastQuestion) {
+      submitQuiz.mutate(
+        {
+          missionId,
+          submissions: {
+            submissions: newAnswers.map((a) => {
+              const quiz = mission.quizzes.find(
+                (q) => q.quizId === a.quizId
+              );
+              let answerToSend = a.userAnswer;
+              if (quiz?.type === "MULTIPLE" && quiz.option) {
+                const optionIndex = quiz.option.indexOf(a.userAnswer);
+                if (optionIndex !== -1) {
+                  answerToSend = String(optionIndex + 1);
+                }
+              }
+              return { quizId: a.quizId, answer: answerToSend };
+            }),
+          },
+        },
+        {
+          onSuccess: () => {
+            navigate("/mypage?tab=mission", { replace: true });
+          },
+          onError: handleMutationError,
+        }
+      );
+    } else {
+      setCurrentQuestionIndex((prev) => prev + 1);
+      setUserInput("");
+      setSelectedOption(null);
+    }
   };
 
   const handleNext = () => {
@@ -352,19 +418,36 @@ function QuizPageContent({ missionId }: { missionId: number }) {
           showFeedback={showFeedback}
           onInputChange={setUserInput}
           onOptionSelect={setSelectedOption}
+          previousCorrectAnswer={
+            isPreviouslyCorrect ? getPreviousCorrectDisplayValue() : null
+          }
         />
       </div>
 
       <div className="mt-auto flex justify-center pt-44 pb-42">
         <div className="h-48 w-full">
           <QuizSubmitButton
-            text={showFeedback ? "다음 문제" : "정답 확인하기"}
+            text={
+              showFeedback
+                ? "다음 문제"
+                : isRetry && isLastQuestion
+                  ? "미션 완료하기"
+                  : isPreviouslyCorrect
+                    ? "다음 문제"
+                    : "정답 확인하기"
+            }
             disabled={
               isAnimating ||
               submitQuiz.isPending ||
-              (!showFeedback && isAnswerEmpty())
+              (!showFeedback && !isPreviouslyCorrect && isAnswerEmpty())
             }
-            onClick={showFeedback ? handleNext : handleSubmit}
+            onClick={
+              showFeedback
+                ? handleNext
+                : isPreviouslyCorrect
+                  ? handleRetryCorrectSkip
+                  : handleSubmit
+            }
           />
         </div>
       </div>

--- a/src/pages/mission/quiz/components/QuizAnswer.tsx
+++ b/src/pages/mission/quiz/components/QuizAnswer.tsx
@@ -9,6 +9,7 @@ interface QuizAnswerProps {
   options?: string[];
   onInputChange: (value: string) => void;
   onOptionSelect: (option: string) => void;
+  previousCorrectAnswer?: string | null;
 }
 
 export default function QuizAnswer({
@@ -18,10 +19,21 @@ export default function QuizAnswer({
   options,
   onInputChange,
   onOptionSelect,
+  previousCorrectAnswer,
 }: QuizAnswerProps) {
   const shouldBlurRef = useRef(false);
+  const isReadOnly = previousCorrectAnswer != null;
 
   if (questionType === "subjective") {
+    if (isReadOnly) {
+      return (
+        <div className="pt-39">
+          <div className="body-2 flex h-139 w-full items-start rounded-xl border-2 border-moamoa-100 bg-moamoa-50 px-14 py-16 text-black">
+            {previousCorrectAnswer}
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="pt-39">
         <textarea
@@ -51,6 +63,49 @@ export default function QuizAnswer({
   }
 
   if (questionType === "ox") {
+    if (isReadOnly) {
+      const isOCorrect = previousCorrectAnswer === "O";
+      return (
+        <div className="flex gap-20 px-13 pt-38 pb-20">
+          <div className="flex flex-1 flex-col items-center">
+            <span
+              className={`body-2 ${isOCorrect ? "text-moamoa-300" : "text-gray-500"}`}
+            >
+              그렇다
+            </span>
+            <div
+              className={`mt-4 flex w-full items-center justify-center rounded-xl border px-25 py-24 ${
+                isOCorrect
+                  ? "border-moamoa-400 bg-moamoa-100"
+                  : "border-gray-300 bg-gray-100"
+              }`}
+            >
+              <div className={isOCorrect ? "" : "[&_path]:fill-gray-500"}>
+                <IcOxO />
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col items-center">
+            <span
+              className={`body-2 ${!isOCorrect ? "text-red-300" : "text-gray-500"}`}
+            >
+              아니다
+            </span>
+            <div
+              className={`mt-4 flex w-full items-center justify-center rounded-xl border p-28 ${
+                !isOCorrect
+                  ? "border-red-300 bg-red-200"
+                  : "border-gray-300 bg-gray-100"
+              }`}
+            >
+              <div className={!isOCorrect ? "" : "[&_path]:fill-gray-500"}>
+                <IcOxX />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="flex gap-20 px-13 pt-38 pb-20">
         <button
@@ -60,10 +115,10 @@ export default function QuizAnswer({
         >
           <span className="body-2 text-moamoa-300">그렇다</span>
           <div
-            className={`mt-4 flex w-full items-center justify-center rounded-xl border-2 px-25 py-24 transition-colors ${
+            className={`mt-4 flex w-full items-center justify-center rounded-xl border px-25 py-24 transition-colors ${
               userInput === "O"
                 ? "border-moamoa-300 bg-moamoa-50"
-                : "border-gray-200 bg-white"
+                : "border-gray-300 bg-white"
             }`}
           >
             <IcOxO />
@@ -74,12 +129,12 @@ export default function QuizAnswer({
           onClick={() => onInputChange("X")}
           className="flex flex-1 flex-col items-center"
         >
-          <span className="body-2 text-red-400">아니다</span>
+          <span className="body-2 text-red-300">아니다</span>
           <div
-            className={`mt-4 flex w-full items-center justify-center rounded-xl border-2 p-28 transition-colors ${
+            className={`mt-4 flex w-full items-center justify-center rounded-xl border p-28 transition-colors ${
               userInput === "X"
-                ? "border-red-400 bg-red-50"
-                : "border-gray-200 bg-white"
+                ? "border-red-300 bg-red-200"
+                : "border-gray-300 bg-white"
             }`}
           >
             <IcOxX />
@@ -90,6 +145,33 @@ export default function QuizAnswer({
   }
 
   if (questionType === "multiple" && options) {
+    if (isReadOnly) {
+      const correctOptionText = options.includes(previousCorrectAnswer!)
+        ? previousCorrectAnswer!
+        : options[Number(previousCorrectAnswer!) - 1] || null;
+
+      return (
+        <div className="pt-29">
+          <p className="body-3 text-center text-moamoa-300">
+            정답을 골라보세요!
+          </p>
+          <div className="flex flex-col gap-20 pt-13">
+            {options.map((option) => (
+              <div
+                key={option}
+                className={`body-4 flex w-full items-center justify-center rounded-md border px-10 py-10 ${
+                  option === correctOptionText
+                    ? "border-moamoa-200 bg-moamoa-50 text-black"
+                    : "border-moamoa-100 bg-white text-black"
+                }`}
+              >
+                {option}
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="pt-29">
         <p className="body-3 text-center text-moamoa-300">정답을 골라보세요!</p>
@@ -101,7 +183,7 @@ export default function QuizAnswer({
               onClick={() => onOptionSelect(option)}
               className={`body-4 flex w-full items-center justify-center rounded-md border px-10 py-10 transition-colors ${
                 selectedOption === option
-                  ? "border-moamoa-300 bg-moamoa-50 text-moamoa-500"
+                  ? "border-moamoa-200 bg-moamoa-50 text-black"
                   : "border-moamoa-100 bg-white text-black hover:bg-moamoa-50"
               }`}
             >

--- a/src/pages/mission/quiz/components/QuizCard.tsx
+++ b/src/pages/mission/quiz/components/QuizCard.tsx
@@ -16,6 +16,7 @@ interface QuizCardProps {
   showFeedback: boolean;
   onInputChange: (value: string) => void;
   onOptionSelect: (option: string) => void;
+  previousCorrectAnswer?: string | null;
 }
 
 export default function QuizCard({
@@ -25,6 +26,7 @@ export default function QuizCard({
   showFeedback,
   onInputChange,
   onOptionSelect,
+  previousCorrectAnswer,
 }: QuizCardProps) {
   return (
     <div className="flex w-full flex-col rounded-2xl bg-white px-18 pt-30 pb-30">
@@ -43,7 +45,6 @@ export default function QuizCard({
             />
           ))}
         </div>
-        {/* 양옆 동그라미 추가 */}
       </div>
 
       {!showFeedback && (
@@ -54,6 +55,7 @@ export default function QuizCard({
           options={question.options}
           onInputChange={onInputChange}
           onOptionSelect={onOptionSelect}
+          previousCorrectAnswer={previousCorrectAnswer}
         />
       )}
     </div>

--- a/src/types/mission/mission.ts
+++ b/src/types/mission/mission.ts
@@ -28,14 +28,13 @@ export interface Category {
   name: string;
 }
 
-// 미션 상세 조회 응답
 export interface MissionDetailResponse {
   missionId: number;
   title: string;
   interest: string;
   videoUrl: string;
-  videoLength: number; // 영상 길이 (초 단위) - 시청 완료 계산용
-  durationMinutes: number; // 예상 소요시간 (분 단위) - 영상 + 퀴즈 시간
+  videoLength: number;
+  durationMinutes: number;
   totalReward: number;
   keyword: string[];
   quizzes: Quiz[];
@@ -52,18 +51,17 @@ export interface Quiz {
   answer: string;
   acceptedAnswers: string[];
   explanation: string;
+  previousCorrectAnswer: string | null;
 }
 
 export type QuizType = "SHORT" | "OX" | "MULTIPLE";
 
-// 시청 완료 응답
 export interface WatchMissionResponse {
   missionId: number;
   isContentWatched: boolean;
   status: MissionStatus;
 }
 
-// 미션 상태 변경 요청/응답
 export type MissionStatusRequest = "NONE" | "SCRAP" | "FAIL";
 
 export interface StatusChangeResponse {
@@ -72,7 +70,6 @@ export interface StatusChangeResponse {
   attemptCount: number;
 }
 
-// 퀴즈 제출 요청/응답
 export interface SubmitQuizRequest {
   submissions: Array<{
     quizId: number;


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #210

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- previousCorrectAnswer 필드 추가하여 재도전 시, 지난번 시도에서 맞았던 문제는 정답 공개
- 영상 시청 후 미션 진입 페이지로 돌아왔을 때 빈 창이 떠있지 않도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 퀴즈 재도전 시 이전에 정답했던 답안을 읽기 전용으로 표시하고, 제출 버튼과 이동 흐름을 상황에 맞게 변경했습니다.

* **개선 사항**
  * 모바일 동영상 열기 및 시청 타이머/세션 처리를 개선했습니다.
  * 팝업 차단 시 사용자 안내와 대체 흐름을 보강했으며, 탭 전환 시 남은 시청시간을 정확히 반영하도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->