### PR TITLE
Fix: iOS PWA 하단 safe-area 이중 적용 제거

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -25,7 +25,7 @@ const RootLayout = () => {
           ref={mainRef}
           className={cn(
             "relative flex h-dvh w-full flex-col overflow-y-auto overflow-x-hidden",
-            "pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left",
+            "pt-safe-top pr-safe-right pl-safe-left",
             bgColor
           )}
         >


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #225

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- iOS PWA 하단 safe-area 이중 적용 제거

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

IOS의 PWA 앱 환경에서 아래 여백 문제가 있다고 해서 수정해봤습니다. 배포 되고 IOS 사용하시는 분들이 테스트 한 번 해주시면 좋을 것 같습니다..!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 화면 하단의 안전 영역 패딩이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->