### PR TITLE
Fix: 카카오 로그인 URL을 백엔드 거치지 않고 카카오로 직접 이동

### DIFF
--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -3,6 +3,8 @@ import { refreshAccessToken } from "@/apis/auth/auth";
 import { storage } from "@/apis/storage";
 import { useAuthStore } from "@/store/auth";
 
+const PUBLIC_PATHS = ["/", "/start", "/login", "/signup", "/find-id", "/password", "/terms", "/oauth/callback"];
+
 export const useAuth = () => {
   const {
     isLoading,
@@ -27,6 +29,14 @@ export const useAuth = () => {
         setLoading(false);
         return;
       }
+
+      const isPublicPath = PUBLIC_PATHS.includes(window.location.pathname);
+      if (isPublicPath) {
+        setAuthenticated(false);
+        setLoading(false);
+        return;
+      }
+
       try {
         const newToken = await refreshAccessToken();
         storage.setToken(newToken);

--- a/src/pages/auth/login/components/SocialLoginButtons.tsx
+++ b/src/pages/auth/login/components/SocialLoginButtons.tsx
@@ -6,7 +6,12 @@ export default function SocialLoginButtons() {
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/auth/social/google`;
   };
   const handleKakaoLogin = () => {
-    window.location.href = `${import.meta.env.VITE_API_BASE_URL}/auth/social/kakao`;
+    const params = new URLSearchParams({
+      client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
+      redirect_uri: `${window.location.origin}/oauth/callback`,
+      response_type: "code",
+    });
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?${params}`;
   };
 
   return (

--- a/src/pages/auth/login/components/SocialLoginButtons.tsx
+++ b/src/pages/auth/login/components/SocialLoginButtons.tsx
@@ -6,10 +6,13 @@ export default function SocialLoginButtons() {
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/auth/social/google`;
   };
   const handleKakaoLogin = () => {
+    const state = crypto.randomUUID();
+    sessionStorage.setItem("oauth_state", state);
     const params = new URLSearchParams({
       client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
       redirect_uri: `${window.location.origin}/oauth/callback`,
       response_type: "code",
+      state,
     });
     window.location.href = `https://kauth.kakao.com/oauth/authorize?${params}`;
   };

--- a/src/pages/auth/oauth-callback/OAuthCallback.tsx
+++ b/src/pages/auth/oauth-callback/OAuthCallback.tsx
@@ -20,6 +20,14 @@ export default function OAuthCallback() {
         return;
       }
 
+      const state = searchParams.get("state");
+      const savedState = sessionStorage.getItem("oauth_state");
+      if (state && savedState && state !== savedState) {
+        setErrorMessage("잘못된 요청입니다.");
+        return;
+      }
+      sessionStorage.removeItem("oauth_state");
+
       const code = searchParams.get("code");
       if (!code) {
         setErrorMessage("소셜 로그인 코드가 없습니다.");

--- a/src/pages/auth/oauth-callback/OAuthCallback.tsx
+++ b/src/pages/auth/oauth-callback/OAuthCallback.tsx
@@ -22,7 +22,7 @@ export default function OAuthCallback() {
 
       const state = searchParams.get("state");
       const savedState = sessionStorage.getItem("oauth_state");
-      if (state && savedState && state !== savedState) {
+      if (savedState && state !== savedState) {
         setErrorMessage("잘못된 요청입니다.");
         return;
       }


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #223

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
카카오 로그인 URL을 백엔드 거치지 않고 카카오로 직접 이동

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

로컬에서는 잘 되고 배포 후 인스타 웹 뷰에서 확인해봐야할 것 같습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Kakao 로그인 흐름을 클라이언트 측 OAuth로 전환하여 인증 경험을 개선했습니다.
  * 공개 페이지에서는 불필요한 토큰 갱신을 건너뛰어 페이지 접근이 더 원활해졌습니다.
* **버그 수정**
  * OAuth 콜백에서 상태(state) 검증을 추가해 잘못된 요청에 대해 오류 안내("잘못된 요청입니다.")를 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->