### PR TITLE
Fix: 재도전 후 미션 완료하기 버튼 누르면 마이페이지 다시풀기 탭으로 이동

### DIFF
--- a/src/pages/mission/quiz/QuizPage.tsx
+++ b/src/pages/mission/quiz/QuizPage.tsx
@@ -207,7 +207,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
         },
         {
           onSuccess: () => {
-            navigate("/mypage?tab=mission", { replace: true });
+            navigate("/mypage?tab=mission&view=retry", { replace: true });
           },
           onError: handleMutationError,
         }
@@ -264,7 +264,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
         {
           onSuccess: (data) => {
             if (isRetry) {
-              navigate("/mypage?tab=mission", { replace: true });
+              navigate("/mypage?tab=mission&view=retry", { replace: true });
             } else {
               setQuizResult({
                 isSuccess: data.isSuccess,
@@ -430,7 +430,7 @@ function QuizPageContent({ missionId }: { missionId: number }) {
             text={
               showFeedback
                 ? "다음 문제"
-                : isRetry && isLastQuestion
+                : isPreviouslyCorrect && isLastQuestion
                   ? "미션 완료하기"
                   : isPreviouslyCorrect
                     ? "다음 문제"

--- a/src/pages/mission/quiz/components/QuizFirstFailResult.tsx
+++ b/src/pages/mission/quiz/components/QuizFirstFailResult.tsx
@@ -65,7 +65,7 @@ export default function QuizFirstFailResult({
           onClick={onNext}
           className="body-2-1 mt-18 h-48 w-full rounded-xl bg-moamoa-300 text-white"
         >
-          {isLastQuestion ? "미션 완료하기" : "다음 문제"}
+          {isLastQuestion ? "결과 확인하기" : "다음 문제"}
         </button>
       </div>
     </div>


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #232

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 재도전 이후 미션 완료하기 버튼 클릭 시 마이페이지의 다시 풀기 탭으로 이동
- 첫 도전 마지막 문제 피드백 화면의 미션 완료하기와 결과 확인하기 버튼을 통일


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 퀴즈 미션 재시도 시 네비게이션 경로 개선
* 퀴즈 진행 중 버튼 라벨 및 동작 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->