### PR TITLE
Fix: 로그인 후 출석 체크 요청 지연 해결

### DIFF
--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -16,43 +16,44 @@ export const useAppInitializer = ({
   callbacksRef.current = { onCheckAttendance, onCheckGoalPopups };
 
   const prevPathnameRef = useRef(window.location.pathname);
+  const hasInitRef = useRef(false);
 
-  useEffect(() => {
-    // 중복 호출 방지하며 목표 팝업 실행
-    const runGoalPopupsIfNeeded = () => {
-      const store = useAttendanceStore.getState();
-      if (!store.onModalClosed) {
-        callbacksRef.current.onCheckGoalPopups();
-      }
-    };
+  const runGoalPopupsIfNeeded = () => {
+    const store = useAttendanceStore.getState();
+    if (!store.onModalClosed) {
+      callbacksRef.current.onCheckGoalPopups();
+    }
+  };
 
-    const runChecks = async () => {
-      const token = storage.getToken();
-      if (!token) return;
+  const runChecks = async () => {
+    const token = storage.getToken();
+    if (!token) return;
 
-      const isOnboardingPage =
-        window.location.pathname.startsWith("/onboarding");
-      if (isOnboardingPage) return;
+    const isOnboardingPage = window.location.pathname.startsWith("/onboarding");
+    if (isOnboardingPage) return;
 
-      try {
-        const modalShown =
-          await callbacksRef.current.onCheckAttendance();
+    try {
+      const modalShown = await callbacksRef.current.onCheckAttendance();
 
-        if (modalShown) {
-          useAttendanceStore
-            .getState()
-            .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
-        } else {
-          runGoalPopupsIfNeeded();
-        }
-      } catch (error) {
-        console.error("출석 체크 실패:", error);
+      if (modalShown) {
+        useAttendanceStore
+          .getState()
+          .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
+      } else {
         runGoalPopupsIfNeeded();
       }
-    };
+    } catch (error) {
+      console.error("출석 체크 실패:", error);
+      runGoalPopupsIfNeeded();
+    }
+  };
 
+  if (!hasInitRef.current) {
+    hasInitRef.current = true;
     runChecks();
+  }
 
+  useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         runChecks();


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #237 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
로그인 후 check 요청이 home 요청과 동시에 가지 않고 지연되어 발생하여 호출 시점을 앞당김

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>
렌더 중 side effect 실행은 원칙적으로 비권장이지만 React 공식 문서에서 ref를 활용한 one-time initialization은 허용되는 패턴으로 안내하고 있어서 출석에 해당하는 경우는 괜찮을 것 같다고 생각했습니다.. 괜찮을까요?