### PR TITLE
Fix: 온보딩 PATCH 기본값/null 처리 개선

### DIFF
--- a/src/pages/onboarding/Onboarding.tsx
+++ b/src/pages/onboarding/Onboarding.tsx
@@ -23,13 +23,18 @@ export default function Onboarding() {
 
   const handleSubmit = (
     nextPayload: OnboardingPayload,
-    dailyMissionGoal: number
+    dailyMissionGoal: number | null
   ) => {
     const request: OnboardingRequest = {
       selections: nextPayload.selections,
-      dailyMissionGoal,
-      goalRetention: nextPayload.goalRetention ?? "CONTINUE",
     };
+    if (dailyMissionGoal === null) {
+      request.dailyMissionGoal = null;
+      request.goalRetention = null;
+    } else {
+      request.dailyMissionGoal = dailyMissionGoal;
+      request.goalRetention = nextPayload.goalRetention ?? "CONTINUE";
+    }
 
     updateOnboardingMutation(request);
     setCurrentStep(5);

--- a/src/pages/onboarding/Onboarding.tsx
+++ b/src/pages/onboarding/Onboarding.tsx
@@ -17,7 +17,7 @@ export default function Onboarding() {
     selections: [],
     dailyMissionTime: null,
     dailyMissionGoal: null,
-    goalRetention: "ONE_WEEK",
+    goalRetention: "CONTINUE",
   });
   const { mutate: updateOnboardingMutation } = useUpdateOnboarding();
 
@@ -28,7 +28,7 @@ export default function Onboarding() {
     const request: OnboardingRequest = {
       selections: nextPayload.selections,
       dailyMissionGoal,
-      goalRetention: nextPayload.goalRetention ?? "ONE_WEEK",
+      goalRetention: nextPayload.goalRetention ?? "CONTINUE",
     };
 
     updateOnboardingMutation(request);

--- a/src/pages/onboarding/views/OnboardingStep4View.tsx
+++ b/src/pages/onboarding/views/OnboardingStep4View.tsx
@@ -4,7 +4,7 @@ import type { OnboardingPayload } from "@/types/onboarding/onboarding";
 interface OnboardingStep4ViewProps {
   payload: OnboardingPayload;
   onChange: (next: OnboardingPayload) => void;
-  onSubmit: (next: OnboardingPayload, dailyMissionGoal: number) => void;
+  onSubmit: (next: OnboardingPayload, dailyMissionGoal: number | null) => void;
 }
 
 export default function OnboardingStep4View({
@@ -105,10 +105,11 @@ export default function OnboardingStep4View({
             onClick={() => {
               const nextPayload = {
                 ...payload,
-                dailyMissionGoal: minSelectable,
+                dailyMissionGoal: null,
+                goalRetention: null,
               };
               onChange(nextPayload);
-              onSubmit(nextPayload, minSelectable);
+              onSubmit(nextPayload, null);
             }}
           >
             나중에 설정

--- a/src/pages/onboarding/views/OnboardingStep4View.tsx
+++ b/src/pages/onboarding/views/OnboardingStep4View.tsx
@@ -13,14 +13,18 @@ export default function OnboardingStep4View({
   onSubmit,
 }: OnboardingStep4ViewProps) {
   const min = 0;
+  const minSelectable = 1;
   const max = 5;
-  const value = payload.dailyMissionGoal ?? 0;
+  const value = Math.max(
+    minSelectable,
+    payload.dailyMissionGoal ?? minSelectable
+  );
   const percent = ((value - min) / (max - min)) * 100;
 
   const handleSliderChange = (nextValue: number) => {
     onChange({
       ...payload,
-      dailyMissionGoal: Math.min(max, Math.max(min, nextValue)),
+      dailyMissionGoal: Math.min(max, Math.max(minSelectable, nextValue)),
     });
   };
 
@@ -99,9 +103,12 @@ export default function OnboardingStep4View({
             type="button"
             className="body-2 h-50 rounded-lg bg-moamoa-300 py-12 text-white active:bg-moamoa-500"
             onClick={() => {
-              const nextPayload = { ...payload, dailyMissionGoal: null };
+              const nextPayload = {
+                ...payload,
+                dailyMissionGoal: minSelectable,
+              };
               onChange(nextPayload);
-              onSubmit(nextPayload, 0);
+              onSubmit(nextPayload, minSelectable);
             }}
           >
             나중에 설정

--- a/src/types/onboarding/onboarding.ts
+++ b/src/types/onboarding/onboarding.ts
@@ -13,20 +13,20 @@ export type OnboardingPayload = {
 export type OnboardingRequest = {
   selections: OnboardingSelection[];
   dailyMissionGoal?: number | null;
-  goalRetention?:
+  goalRetention?: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE" | null;
+};
+
+export type OnboardingApiResponse = {
+  selections: OnboardingSelection[];
+  dailyMissionGoal: number | null;
+  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE" | null;
+  goalEndDate: string;
+  pendingDailyMissionGoal: number;
+  pendingGoalRetention:
     | "ONE_WEEK"
     | "TWO_WEEKS"
     | "ONE_MONTH"
     | "CONTINUE"
     | null;
-};
-
-export type OnboardingApiResponse = {
-  selections: OnboardingSelection[];
-  dailyMissionGoal: number;
-  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE";
-  goalEndDate: string;
-  pendingDailyMissionGoal: number;
-  pendingGoalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE";
   pendingApplyDate: string;
 };

--- a/src/types/onboarding/onboarding.ts
+++ b/src/types/onboarding/onboarding.ts
@@ -7,21 +7,21 @@ export type OnboardingPayload = {
   selections: OnboardingSelection[];
   dailyMissionTime?: number | null;
   dailyMissionGoal?: number | null;
-  goalRetention?: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | null;
+  goalRetention?: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE" | null;
 };
 
 export type OnboardingRequest = {
   selections: OnboardingSelection[];
   dailyMissionGoal: number;
-  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH";
+  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE";
 };
 
 export type OnboardingApiResponse = {
   selections: OnboardingSelection[];
   dailyMissionGoal: number;
-  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH";
+  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE";
   goalEndDate: string;
   pendingDailyMissionGoal: number;
-  pendingGoalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH";
+  pendingGoalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE";
   pendingApplyDate: string;
 };

--- a/src/types/onboarding/onboarding.ts
+++ b/src/types/onboarding/onboarding.ts
@@ -12,8 +12,13 @@ export type OnboardingPayload = {
 
 export type OnboardingRequest = {
   selections: OnboardingSelection[];
-  dailyMissionGoal: number;
-  goalRetention: "ONE_WEEK" | "TWO_WEEKS" | "ONE_MONTH" | "CONTINUE";
+  dailyMissionGoal?: number | null;
+  goalRetention?:
+    | "ONE_WEEK"
+    | "TWO_WEEKS"
+    | "ONE_MONTH"
+    | "CONTINUE"
+    | null;
 };
 
 export type OnboardingApiResponse = {


### PR DESCRIPTION
## 🚀 관련 이슈

- close #251 

## 🔑 작업 내용

* 계속하기 경로에서 목표값 최소 1 이상만 허용하도록 프론트 보장
* 나중에 설정 경로에서 dailyMissionGoal, goalRetention을 null로 전송
* goalRetention 기본값 CONTINUE로 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 목표 지속 옵션에 "계속" 추가 — 목표를 무기한 유지 가능

* **개선 사항**
  * 온보딩에서 일일 미션 목표를 "나중에 설정"으로 남길 수 있도록 지원 (값을 비워 전달)
  * 목표 지속의 기본값을 "계속"으로 변경
  * 목표 선택 UI: 슬라이더 값이 최소/최대 범위 내로 안전하게 고정되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->