### PR TITLE
Fix: 로그인 직후 출석 체크 미실행 및 로그아웃 시 상태 잔류 문제 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import GlobalModals from "./components/GlobalModals";
 import GoalPopups from "./components/GoalPopups";
+import { RunChecksContext } from "./context/RunChecksContext";
 import { useAttendanceCheck } from "./hooks/attendance/useAttendanceCheck";
 import { useGoalPopupCheck } from "./hooks/goal/useGoalPopupCheck";
 import { useAppInitializer } from "./hooks/useAppInitializer";
@@ -17,15 +18,17 @@ function App() {
     handleClosePopup,
     handleMissionExplore,
     resetNavigateToSearch,
+    resetGoalPopups,
   } = useGoalPopupCheck();
   const showLogoutToast = useSettingsStore((state) => state.showLogoutToast);
   const setShowLogoutToast = useSettingsStore(
     (state) => state.setShowLogoutToast
   );
 
-  useAppInitializer({
+  const { runChecks } = useAppInitializer({
     onCheckAttendance: handleCheckAttendance,
     onCheckGoalPopups: handleCheckGoalPopups,
+    onReset: resetGoalPopups,
   });
 
   useEffect(() => {
@@ -45,7 +48,7 @@ function App() {
   }, [showLogoutToast, setShowLogoutToast]);
 
   return (
-    <>
+    <RunChecksContext.Provider value={runChecks}>
       <RouterProvider router={router} />
       <GoalPopups
         currentPopup={currentPopup}
@@ -53,7 +56,7 @@ function App() {
         onMissionExplore={handleMissionExplore}
       />
       <GlobalModals />
-    </>
+    </RunChecksContext.Provider>
   );
 }
 

--- a/src/context/RunChecksContext.ts
+++ b/src/context/RunChecksContext.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export const RunChecksContext = createContext<(() => Promise<void>) | null>(
+  null
+);
+
+export const useRunChecks = () => {
+  const runChecks = useContext(RunChecksContext);
+  if (!runChecks) throw new Error("RunChecksContext not found");
+  return runChecks;
+};

--- a/src/hooks/goal/useGoalPopupCheck.ts
+++ b/src/hooks/goal/useGoalPopupCheck.ts
@@ -11,6 +11,7 @@ export const useGoalPopupCheck = () => {
   const markShownMutation = useMarkGoalPopupShown();
 
   const handleCheckGoalPopups = async () => {
+    // 이미 체크 중이거나 팝업이 표시 중이면 중복 호출 방지
     if (isCheckingRef.current || popupQueue.length > 0) return;
 
     isCheckingRef.current = true;
@@ -63,6 +64,14 @@ export const useGoalPopupCheck = () => {
     setShouldNavigateToSearch(false);
   };
 
+  // 로그아웃 시 이전 세션의 팝업 큐 초기화
+  const resetGoalPopups = () => {
+    setPopupQueue([]);
+    setCurrentPopup(null);
+    setShouldNavigateToSearch(false);
+    isCheckingRef.current = false;
+  };
+
   return {
     currentPopup,
     shouldNavigateToSearch,
@@ -70,5 +79,6 @@ export const useGoalPopupCheck = () => {
     handleClosePopup,
     handleMissionExplore,
     resetNavigateToSearch,
+    resetGoalPopups,
   };
 };

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,83 +1,74 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { storage } from "@/apis/storage";
-import router from "@/routes/router";
 import { useAttendanceStore } from "@/store/attendance/attendance";
+import { useAuthStore } from "@/store/auth";
 
 interface UseAppInitializerProps {
   onCheckAttendance: () => Promise<boolean>;
   onCheckGoalPopups: () => void;
+  onReset: () => void;
 }
 
 export const useAppInitializer = ({
   onCheckAttendance,
   onCheckGoalPopups,
+  onReset,
 }: UseAppInitializerProps) => {
-  const callbacksRef = useRef({ onCheckAttendance, onCheckGoalPopups });
-  callbacksRef.current = { onCheckAttendance, onCheckGoalPopups };
+  // 매 렌더마다 최신 콜백을 유지 (stale closure 방지)
+  const callbacksRef = useRef({ onCheckAttendance, onCheckGoalPopups, onReset });
+  callbacksRef.current = { onCheckAttendance, onCheckGoalPopups, onReset };
 
-  const prevPathnameRef = useRef(window.location.pathname);
-  const hasInitRef = useRef(false);
+  // 동시 실행 방지 플래그
+  const isRunningRef = useRef(false);
 
-  const runGoalPopupsIfNeeded = () => {
-    const store = useAttendanceStore.getState();
-    if (!store.onModalClosed) {
-      callbacksRef.current.onCheckGoalPopups();
-    }
-  };
+  // 출석 체크 → 모달 → 골 팝업 순서로 체이닝 실행
+  // useCallback: 무한 재실행 방지
+  const runChecks = useCallback(async () => {
+    if (!storage.getToken()) return;
+    if (isRunningRef.current) return;
 
-  const runChecks = async () => {
-    const token = storage.getToken();
-    if (!token) return;
-
-    const isOnboardingPage = window.location.pathname.startsWith("/onboarding");
-    if (isOnboardingPage) return;
-
+    isRunningRef.current = true;
     try {
       const modalShown = await callbacksRef.current.onCheckAttendance();
 
       if (modalShown) {
+        // 출석 모달을 닫을 때 골 팝업 체이닝
         useAttendanceStore
           .getState()
           .setOnModalClosed(() => callbacksRef.current.onCheckGoalPopups());
       } else {
-        runGoalPopupsIfNeeded();
+        // 출석 모달 없으면 바로 골 팝업 (이미 체이닝 중이면 스킵)
+        if (!useAttendanceStore.getState().onModalClosed) {
+          callbacksRef.current.onCheckGoalPopups();
+        }
       }
     } catch (error) {
       console.error("출석 체크 실패:", error);
-      runGoalPopupsIfNeeded();
+    } finally {
+      isRunningRef.current = false;
     }
-  };
-
-  if (!hasInitRef.current) {
-    hasInitRef.current = true;
-    runChecks();
-  }
+  }, []);
 
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        runChecks();
+    // 로그아웃 시 이전 세션 스토어 초기화
+    const unsubAuth = useAuthStore.subscribe((state, prevState) => {
+      if (prevState.isAuthenticated && !state.isAuthenticated) {
+        useAttendanceStore.getState().reset();
+        callbacksRef.current.onReset();
       }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    const unsubscribe = router.subscribe((state) => {
-      const pathname = state.location.pathname;
-      const prevPathname = prevPathnameRef.current;
-      if (
-        prevPathname.startsWith("/onboarding") &&
-        !pathname.startsWith("/onboarding")
-      ) {
-        runChecks();
-      }
-
-      prevPathnameRef.current = pathname;
     });
 
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      unsubscribe();
+    // 탭 전환 후 포그라운드 복귀 시 다시 체크
+    const onVisible = () => {
+      if (document.visibilityState === "visible") runChecks();
     };
-  }, []);
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      unsubAuth();
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [runChecks]);
+
+  return { runChecks };
 };

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import AsyncBoundary from "@/components/AsyncBoundary";
+import { useRunChecks } from "@/context/RunChecksContext";
 import { useBgmStore } from "@/store/bgm";
 import HomeContent from "./components/HomeContent";
 import useBgm from "./hooks/useBgm";
@@ -7,6 +9,13 @@ const HomePage = () => {
   const bgmEnabled = useBgmStore((s) => s.enabled);
   const setBgmEnabled = useBgmStore((s) => s.setEnabled);
   useBgm("/audio/bgm.mp3", 0.3, bgmEnabled);
+
+  const runChecks = useRunChecks();
+
+  // 홈 마운트 시 출석 체크 실행 (로그인/온보딩 완료 후 진입 시 커버)
+  useEffect(() => {
+    runChecks();
+  }, [runChecks]);
 
   return (
     <AsyncBoundary>

--- a/src/store/attendance/attendance.ts
+++ b/src/store/attendance/attendance.ts
@@ -12,13 +12,20 @@ interface AttendanceStore {
   setShowModal: (show: boolean) => void;
   setAttendanceData: (data: AttendanceData) => void;
   setOnModalClosed: (callback: (() => void) | null) => void;
+  reset: () => void;
 }
 
-export const useAttendanceStore = create<AttendanceStore>((set) => ({
+// reset() 호출 시 복원할 초기값
+const initialState = {
   showModal: false,
   attendanceData: null,
   onModalClosed: null,
+};
+
+export const useAttendanceStore = create<AttendanceStore>((set) => ({
+  ...initialState,
   setShowModal: (show) => set({ showModal: show }),
   setAttendanceData: (data) => set({ attendanceData: data }),
   setOnModalClosed: (callback) => set({ onModalClosed: callback }),
+  reset: () => set(initialState),
 }));


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #255 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
변경 파일 및 역할

  src/context/RunChecksContext.ts (신규)

  runChecks 함수를 컴포넌트 트리 어디서든 사용할 수 있도록 Context를 제공합니다.
  - RunChecksContext: runChecks를 담는 Context 객체
  - useRunChecks(): 하위 컴포넌트에서 runChecks를 꺼내 쓰는 커스텀 훅

  ---
  src/hooks/useAppInitializer.ts

  출석 체크 → 모달 → 골 팝업 체이닝 로직을 정의하고, 부수 트리거(로그아웃, 포그라운드 복귀)를 관리합니다.
  - runChecks(): 출석 체크 API 호출 후 모달 표시 여부에 따라 골 팝업 체이닝 실행. useCallback으로 useEffect의 무한 재실행 방지
  - callbacksRef: 매 렌더마다 최신 콜백을 유지해 stale closure 방지
  - isRunningRef: 동시 중복 실행 방지
  - useAuthStore.subscribe: 로그아웃 감지 시 이전 세션 스토어 초기화
  - visibilitychange 이벤트: 탭 전환 후 포그라운드 복귀 시 runChecks() 재실행
  - 반환값 { runChecks }: Context를 통해 Home으로 전달

  ---
  src/App.tsx

  runChecks를 RunChecksContext.Provider를 통해 하위 컴포넌트에 전달합니다.
  - useAppInitializer에서 runChecks를 받아 RunChecksContext.Provider의 value로 주입
  - resetGoalPopups를 onReset으로 전달해 로그아웃 시 팝업 큐 초기화 연결

  ---
  src/pages/home/Home.tsx

  홈 마운트 시점에 runChecks()를 직접 호출합니다.
  - 로그인 성공 → AuthGuard → navigate("/home") → Home 마운트 → useEffect → runChecks()
  - 이 시점은 로그인 mutation의 onSuccess가 완전히 종료된 이후이므로 mutation 충돌 없음
  - 온보딩 완료 후 navigate("/home")도 동일하게 커버

  ---
  src/store/attendance/attendance.ts

  출석 관련 전역 상태를 관리합니다.
  - reset() 추가: 로그아웃 시 showModal, attendanceData, onModalClosed를 초기값으로 되돌림
  - initialState를 분리해 reset()에서 재사용

  ---
  src/hooks/goal/useGoalPopupCheck.ts

  목표 달성 실패 팝업 큐를 관리합니다.
  - resetGoalPopups() 추가: 로그아웃 시 popupQueue, currentPopup, isCheckingRef를 초기화해 새 계정 로그인 시 이전 세션 팝업이 잔류하지 않도록 처리

  ---
  흐름

  로그인 성공
  → AuthGuard: navigate("/home")
  → Home 마운트 → useEffect → runChecks()
  → POST /attendance/check
  → 출석 모달 표시 → 닫기 → 목표 팝업 체이닝

  로그아웃
  → useAuthStore.subscribe 감지
  → attendanceStore.reset() + resetGoalPopups()
  → 다음 로그인 시 깨끗한 상태에서 시작 

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
|로그인 후 플로우|
|---|
|![화면 기록 2026-02-19 오후 5 32 39](https://github.com/user-attachments/assets/1c0fb513-df47-4c9e-b09c-4b08632c1077)|


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
지금 이미 출석 체크가 돼 있어 보이지 않지만 홈 마운트 시 check 요청이 가기 때문에 출석 미완료 상태시 체크가 바로 뜰 것으로 예상됩니다.
대강 흐름 및 함수의 역할에 대해 간략하게 설명해두었습니다.. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앱을 다시 방문할 때 자동으로 출석 확인을 수행하도록 개선했습니다.

* **버그 수정**
  * 로그아웃 시 상태가 제대로 초기화되지 않던 문제를 해결했습니다.
  * 동시 실행으로 인한 체크 기능의 중복 실행 문제를 수정했습니다.

* **리팩토링**
  * 앱 초기화 및 상태 관리 흐름을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->