### PR TITLE
Fix: 다람쥐 합체 시점 통일

### DIFF
--- a/src/pages/home/components/AvatarBoard.tsx
+++ b/src/pages/home/components/AvatarBoard.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import faceDefault from "@/assets/icons/home/character/items/emotion/ic_face_default.svg";
 import shadowDefault from "@/assets/icons/home/character/shadow/ic_shadow_default.svg";
 import shadowField from "@/assets/icons/home/character/shadow/ic_shadow_field.svg";
@@ -34,8 +35,19 @@ const AvatarBoard = ({ equippedItems }: AvatarBoardProps) => {
     ? BACKGROUND_SHADOW_MAP[backgroundId]
     : shadowDefault;
 
+  const totalImages = 2 + itemEntries.length; // squirrel + face + 장착 아이템
+  const [loadedCount, setLoadedCount] = useState(0);
+  const allLoaded = loadedCount >= totalImages;
+
+  const handleImageSettle = useCallback(() => {
+    setLoadedCount((c) => c + 1);
+  }, []);
+
   return (
-    <div className="relative h-360 w-360">
+    <div
+      className="relative h-360 w-360"
+      style={{ opacity: allLoaded ? 1 : 0 }}
+    >
       {shadowSrc && (
         <img
           src={shadowSrc}
@@ -50,6 +62,8 @@ const AvatarBoard = ({ equippedItems }: AvatarBoardProps) => {
         alt="다람쥐 캐릭터"
         className="absolute inset-0 h-full w-full"
         style={{ zIndex: 1 }}
+        onLoad={handleImageSettle}
+        onError={handleImageSettle}
       />
 
       <img
@@ -57,6 +71,8 @@ const AvatarBoard = ({ equippedItems }: AvatarBoardProps) => {
         alt={equippedItems.FACE?.name ?? "기본 표정"}
         className="absolute inset-0 h-full w-full"
         style={{ zIndex: AVATAR_LAYER_ORDER.FACE }}
+        onLoad={handleImageSettle}
+        onError={handleImageSettle}
       />
 
       {itemEntries.map(([type, item]) => (
@@ -66,6 +82,8 @@ const AvatarBoard = ({ equippedItems }: AvatarBoardProps) => {
           alt={item.name}
           className="absolute inset-0 h-full w-full"
           style={{ zIndex: AVATAR_LAYER_ORDER[type] }}
+          onLoad={handleImageSettle}
+          onError={handleImageSettle}
         />
       ))}
     </div>


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #266 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 다람쥐 합체 시점 통일

서버 아이템 imageUrl: API 응답 기다리는 동안 브라우저가 DNS lookup, 연결
등을 미리 준비한 CDN에서 옴
squirrelDefault: 번들된 JS가 파싱된 뒤에야 경로가 확정되고, 앱 호스팅
서버에서 별도 fetch

에서 오는 로딩 시점 차이를 onLoad로 보여주는 시점 통일했습니다.

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>
- 분명히 다른 좋은 방식이 있을 것 같은데 일단 프론트단에서 해결할 수 있는대로 해봤습니다.