### PR TITLE
Design: 입력 필드 폰트 사이즈 수정

### DIFF
--- a/src/pages/auth/components/AuthTextField.tsx
+++ b/src/pages/auth/components/AuthTextField.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useId } from "react";
+import { cn } from "@/utils/cn/cn";
 import { textFieldVariants } from "./authTextField.variants";
 
 export type AuthTextFieldProps = {
@@ -20,6 +21,7 @@ export type AuthTextFieldProps = {
   name?: string;
   endAdornment?: ReactNode;
   endAdornmentPaddingClassName?: string;
+  className?: string;
 };
 
 export function AuthTextField({
@@ -38,6 +40,7 @@ export function AuthTextField({
   name,
   endAdornment,
   endAdornmentPaddingClassName,
+  className,
 }: AuthTextFieldProps) {
   const reactId = useId();
 
@@ -55,7 +58,7 @@ export function AuthTextField({
     ? (endAdornmentPaddingClassName ?? "pr-44")
     : "";
 
-  const inputClassName = `${baseClassName} ${paddingRight}`;
+  const inputClassName = cn(baseClassName, paddingRight, className);
 
   return (
     <div className="flex flex-col gap-10">

--- a/src/pages/auth/components/authTextField.variants.ts
+++ b/src/pages/auth/components/authTextField.variants.ts
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 export const textFieldVariants = cva(
   [
     "px-13 py-8 rounded-lg",
-    "body-4 text-gray-900 placeholder:text-gray-500",
+    "body-2 text-gray-900 placeholder:text-gray-500",
     "transition-colors",
     "focus:outline focus:outline-1 focus:outline-moamoa-300 focus:outline-offset-[-1px]",
   ],

--- a/src/pages/auth/signup/components/EmailDomainSelect.tsx
+++ b/src/pages/auth/signup/components/EmailDomainSelect.tsx
@@ -77,57 +77,46 @@ export default function EmailDomainSelect({
         className
       )}
     >
-      {/* 🔥 수정: !open 조건으로 드롭다운 열렸을 때 선택 버튼만 숨김 */}
-      {!open && (
-        <>
-          {isDirectInput ? (
-            <input
-              value={directValue}
-              onChange={(e) => handleDirectChange(e.target.value)}
-              disabled={disabled}
-              placeholder="직접입력"
-              className={cn(
-                "body-4 w-full bg-transparent outline-none",
-                !disabled &&
-                  "focus:outline focus:outline-1 focus:outline-moamoa-300",
-                disabled ? "cursor-not-allowed text-gray-900" : "text-gray-900"
-              )}
-            />
-          ) : (
-            <button
-              type="button"
-              disabled={disabled}
-              onClick={() => setOpen((p) => !p)}
-              className={cn(
-                "body-4 w-full bg-transparent text-left outline-none",
-                disabled
-                  ? "cursor-not-allowed text-gray-900"
-                  : "cursor-pointer",
-                value ? "text-gray-900" : "text-gray-500"
-              )}
-            >
-              {buttonText}
-            </button>
-          )}
-        </>
-      )}
+      {!open &&
+        (isDirectInput ? (
+          <input
+            value={directValue}
+            onChange={(e) => handleDirectChange(e.target.value)}
+            disabled={disabled}
+            placeholder="직접입력"
+            className={cn(
+              "body-4 w-full bg-transparent outline-none",
+              !disabled && "focus:outline-1 focus:outline-moamoa-300",
+              disabled ? "cursor-not-allowed text-gray-900" : "text-gray-900"
+            )}
+          />
+        ) : (
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => setOpen((p) => !p)}
+            className={cn(
+              "body-4 w-full bg-transparent text-left outline-none",
+              disabled ? "cursor-not-allowed text-gray-900" : "cursor-pointer",
+              value ? "text-gray-900" : "text-gray-500"
+            )}
+          >
+            {buttonText}
+          </button>
+        ))}
 
-      {/* 🔥 수정: 아이콘은 항상 표시, 열렸을 때는 클릭 가능 */}
-      {!hideIcon && (
-        <>
-          {open ? (
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="absolute top-1/2 right-10 -translate-y-1/2 cursor-pointer"
-            >
-              <IcDropdownClose />
-            </button>
-          ) : (
-            <IcDropdownOpen className="pointer-events-none absolute top-1/2 right-10 -translate-y-1/2" />
-          )}
-        </>
-      )}
+      {!hideIcon &&
+        (open ? (
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="absolute top-1/2 right-10 -translate-y-1/2 cursor-pointer"
+          >
+            <IcDropdownClose />
+          </button>
+        ) : (
+          <IcDropdownOpen className="pointer-events-none absolute top-1/2 right-10 -translate-y-1/2" />
+        ))}
 
       {open && !disabled && !isDirectInput && (
         <div

--- a/src/pages/auth/signup/components/EmailVerifySection.tsx
+++ b/src/pages/auth/signup/components/EmailVerifySection.tsx
@@ -60,13 +60,14 @@ export default function EmailVerifySection({
           <AuthTextField
             placeholder="이메일을 입력해주세요"
             value={emailLocal}
-          onChange={onChangeEmailLocal}
-          width="full"
-          height="sm"
-          variant="ghost"
-          disabled={isVerified || disabledEmailInput}
-        />
-      </div>
+            onChange={onChangeEmailLocal}
+            width="full"
+            height="sm"
+            variant="ghost"
+            disabled={isVerified || disabledEmailInput}
+            className="body-4"
+          />
+        </div>
 
         <span className="body-2 mr-2 ml-4 text-gray-700">@</span>
 
@@ -100,6 +101,7 @@ export default function EmailVerifySection({
             width="full"
             height="sm"
             disabled={isVerified}
+            className="body-4"
           />
         </div>
         <div className="ml-12">

--- a/src/pages/settings/components/inquiry/InquiryTextFields.tsx
+++ b/src/pages/settings/components/inquiry/InquiryTextFields.tsx
@@ -28,7 +28,7 @@ export default function InquiryTextFields({
             onChange={(e) => onChangeTitle(e.target.value)}
             placeholder="제목을 입력해 주세요 (20자 이내)"
             maxLength={20}
-            className="body-4 w-full bg-transparent text-black outline-none placeholder:text-gray-400"
+            className="body-2 w-full bg-transparent text-black outline-none placeholder:text-gray-400"
           />
           <span className="body-4 ml-10 whitespace-nowrap text-center text-positive">
             {titleCount}
@@ -47,7 +47,7 @@ export default function InquiryTextFields({
           onChange={(e) => onChangeContent(e.target.value)}
           placeholder="내용을 입력해 주세요."
           maxLength={2000}
-          className="body-4 h-221 w-full resize-none rounded-sm border border-gray-400 bg-transparent p-10 text-black outline-none placeholder:text-gray-400"
+          className="body-2 h-221 w-full resize-none rounded-sm border border-gray-400 bg-transparent p-10 text-black outline-none placeholder:text-gray-400"
         />
 
         <div className="mt-6 flex w-full justify-end">


### PR DESCRIPTION
## 🚀 관련 이슈

- close #270 

## 🔑 작업 내용

기존 폰트 사이즈가 body-4로 아이폰에서 자동 확대되는 현상이 있어서 body-2로 수정했습니다. (디자인 수정사항)

로그인 페이지
회원가입 페이지
비밀번호 재설정 페이지
비밀번호 변경 페이지
문의하기 페이지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 인증 페이지의 텍스트 필드 타이포그래피 업데이트
  * 설정 페이지 문의 양식의 텍스트 크기 조정
  * 폼 입력 필드의 시각적 일관성 개선

* **리팩터**
  * 이메일 도메인 선택 컴포넌트의 렌더링 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->