### PR TITLE
Fix: 계정 전환 시 이전 계정 데이터 캐시 초기화

### DIFF
--- a/src/pages/auth/login/hooks/useMutation/useLogin.ts
+++ b/src/pages/auth/login/hooks/useMutation/useLogin.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { login } from "@/apis/auth/auth";
 import { storage } from "@/apis/storage";
 import { useApiError } from "@/hooks/api/useApiError";
@@ -26,6 +26,7 @@ const resolveLoginErrorMessage = (code?: string, fallback?: string) => {
 
 export const useLogin = (handlers?: LoginErrorHandlers) => {
   const { handleError } = useApiError();
+  const queryClient = useQueryClient();
   const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
   const setOnboardingCompleted = useAuthStore(
@@ -35,6 +36,8 @@ export const useLogin = (handlers?: LoginErrorHandlers) => {
   return useMutation({
     mutationFn: (payload: LoginRequest) => login(payload),
     onSuccess: (result) => {
+      queryClient.removeQueries({ queryKey: ["home"] });
+      queryClient.removeQueries({ queryKey: ["members", "me", "profile"] });
       storage.setToken(result.token.accessToken);
       storage.setPolicyAgreed(result.policyAgreed);
       storage.setOnboardingCompleted(result.onboardingCompleted);

--- a/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
+++ b/src/pages/auth/oauth-callback/hooks/useMutation/useSocialLogin.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { exchangeSocialToken } from "@/apis/auth/auth";
 import { storage } from "@/apis/storage";
 import { useApiError } from "@/hooks/api/useApiError";
@@ -11,6 +11,7 @@ type SocialLoginErrorHandlers = {
 
 export const useSocialLogin = (handlers?: SocialLoginErrorHandlers) => {
   const { handleError } = useApiError();
+  const queryClient = useQueryClient();
   const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const setPolicyAgreed = useAuthStore((state) => state.setPolicyAgreed);
   const setOnboardingCompleted = useAuthStore(
@@ -21,6 +22,8 @@ export const useSocialLogin = (handlers?: SocialLoginErrorHandlers) => {
     mutationFn: (payload: SocialLoginTokenRequest) =>
       exchangeSocialToken(payload),
     onSuccess: (result) => {
+      queryClient.removeQueries({ queryKey: ["home"] });
+      queryClient.removeQueries({ queryKey: ["members", "me", "profile"] });
       storage.setToken(result.token.accessToken);
       storage.setPolicyAgreed(result.policyAgreed);
       storage.setOnboardingCompleted(result.onboardingCompleted);

--- a/src/pages/home/components/AvatarBoard.tsx
+++ b/src/pages/home/components/AvatarBoard.tsx
@@ -84,7 +84,6 @@ const AvatarBoard = ({ equippedItems }: AvatarBoardProps) => {
           style={{ zIndex: AVATAR_LAYER_ORDER[type] }}
           onLoad={handleImageSettle}
           onError={handleImageSettle}
-          그
         />
       ))}
     </div>

--- a/src/pages/home/components/AvatarBoard.tsx
+++ b/src/pages/home/components/AvatarBoard.tsx
@@ -84,6 +84,7 @@ const AvatarBoard = ({ equippedItems }: AvatarBoardProps) => {
           style={{ zIndex: AVATAR_LAYER_ORDER[type] }}
           onLoad={handleImageSettle}
           onError={handleImageSettle}
+          그
         />
       ))}
     </div>


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) Feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #275 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 로그인 성공 시 이전 계정의 React Query 캐시를 제거하도록 useLogin, useSocialLogin 수정                                                                              
- ["home"] 쿼리 제거 (홈 화면 닉네임)                                                                                                                               
- ["members", "me", "profile"] 쿼리 제거 (마이페이지 유저명)         
## 영상
|플로우|
|---|
|![화면 기록 2026-02-20 오전 1 33 00](https://github.com/user-attachments/assets/ab418e96-abd6-4564-b11f-f70b1f42a95e)|

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
 - 로컬 로그인은 SPA 내부 네비게이션이라 캐시가 유지되어 발생한 문제로, 소셜 로그인(페이지 새로고침)과 동작 차이가 있었습니다.                                      
 - queryClient.clear()로 전체 캐시 삭제 시 마이페이지 렌더링 이슈가 있어, 계정 관련 쿼리키만 핀포인트로 제거하는 방식으로 처리했습니다
 - 소셜로그인 하면 배포 주소로 가져서,,, 소셜로그인 -> 로컬 로그인 테스트가 안되는 관계로 머지하고 제가 테스트 하겠습니당.
